### PR TITLE
feat: tag repos when integration tests pass

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,3 +107,81 @@ jobs:
         if: always()
         working-directory: infra
         run: docker compose --profile backend --profile frontend down
+
+  tag-on-success:
+    runs-on: ubuntu-latest
+    needs: [e2e]
+    if: success() && github.event_name == 'push'
+
+    steps:
+      - name: Log tested commits
+        run: |
+          echo "## Tested Commits" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Repo | Commit |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| integration-tests | [${INTEGRATION_SHA:0:7}](https://github.com/kelleyglenn/AcctAtlas-integration-tests/commit/$INTEGRATION_SHA) |" >> $GITHUB_STEP_SUMMARY
+          echo "| user-service | [${USER_SHA:0:7}](https://github.com/kelleyglenn/AcctAtlas-user-service/commit/$USER_SHA) |" >> $GITHUB_STEP_SUMMARY
+          echo "| api-gateway | [${GATEWAY_SHA:0:7}](https://github.com/kelleyglenn/AcctAtlas-api-gateway/commit/$GATEWAY_SHA) |" >> $GITHUB_STEP_SUMMARY
+          echo "| web-app | [${WEBAPP_SHA:0:7}](https://github.com/kelleyglenn/AcctAtlas-web-app/commit/$WEBAPP_SHA) |" >> $GITHUB_STEP_SUMMARY
+        env:
+          INTEGRATION_SHA: ${{ needs.e2e.outputs.integration-tests-sha }}
+          USER_SHA: ${{ needs.e2e.outputs.user-service-sha }}
+          GATEWAY_SHA: ${{ needs.e2e.outputs.api-gateway-sha }}
+          WEBAPP_SHA: ${{ needs.e2e.outputs.web-app-sha }}
+
+      - name: Create tags
+        env:
+          GH_TOKEN: ${{ secrets.INTEGRATION_TEST_PAT }}
+          INTEGRATION_SHA: ${{ needs.e2e.outputs.integration-tests-sha }}
+          USER_SHA: ${{ needs.e2e.outputs.user-service-sha }}
+          GATEWAY_SHA: ${{ needs.e2e.outputs.api-gateway-sha }}
+          WEBAPP_SHA: ${{ needs.e2e.outputs.web-app-sha }}
+        run: |
+          TAG_NAME="integration-tested-$(date +%Y%m%d)-${{ github.run_id }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          echo "Creating tag: $TAG_NAME"
+          echo "Run URL: $RUN_URL"
+
+          tag_repo() {
+            local repo=$1
+            local sha=$2
+            local retries=3
+
+            echo "Tagging $repo at $sha..."
+
+            for ((i=1; i<=retries; i++)); do
+              TAG_SHA=$(gh api "repos/kelleyglenn/${repo}/git/tags" \
+                -f tag="$TAG_NAME" \
+                -f message="Integration tests passed. Run: $RUN_URL" \
+                -f object="$sha" \
+                -f type="commit" \
+                --jq '.sha' 2>/dev/null) || true
+
+              if [ -n "$TAG_SHA" ]; then
+                if gh api "repos/kelleyglenn/${repo}/git/refs" \
+                  -f ref="refs/tags/$TAG_NAME" \
+                  -f sha="$TAG_SHA" >/dev/null 2>&1; then
+                  echo "Successfully tagged $repo"
+                  return 0
+                fi
+              fi
+
+              echo "Attempt $i/$retries failed for $repo, retrying in 2s..."
+              sleep 2
+            done
+
+            echo "::warning::Failed to tag $repo after $retries attempts"
+            return 0
+          }
+
+          tag_repo "AcctAtlas-integration-tests" "$INTEGRATION_SHA"
+          tag_repo "AcctAtlas-user-service" "$USER_SHA"
+          tag_repo "AcctAtlas-api-gateway" "$GATEWAY_SHA"
+          tag_repo "AcctAtlas-web-app" "$WEBAPP_SHA"
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Tag Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`$TAG_NAME\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Add commit SHA outputs to e2e job
- Add tag-on-success job that creates matching tags across repos
- Tags format: `integration-tested-YYYYMMDD-<run_id>`

## Tagged Repos

- AcctAtlas-integration-tests
- AcctAtlas-user-service
- AcctAtlas-api-gateway
- AcctAtlas-web-app

## Prerequisites

Requires `INTEGRATION_TEST_PAT` secret to be configured with write access to all repos.

---

Generated with [Claude Code](https://claude.com/claude-code)