### PR TITLE
fix: update condition for tag-on-success job to include workflow_dispatch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,7 +111,7 @@ jobs:
   tag-on-success:
     runs-on: ubuntu-latest
     needs: [e2e]
-    if: success() && github.event_name == 'push'
+    if: ${{ success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
     steps:
       - name: Log tested commits


### PR DESCRIPTION
Required to be able to trigger the dependent job manually