### PR TITLE
fix(ci): add Mapbox token and step timeouts to workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -113,6 +113,8 @@ jobs:
       - name: Start services
         working-directory: infra
         run: docker compose --profile backend --profile frontend up -d --wait
+        env:
+          NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -130,6 +132,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run API tests
+        timeout-minutes: 10
         run: npm run test:api
         env:
           API_URL: http://localhost:8080/api/v1
@@ -152,6 +155,7 @@ jobs:
           retention-days: 14
 
       - name: Run E2E tests
+        timeout-minutes: 10
         run: npm run test:e2e
         env:
           BASE_URL: http://localhost:3000


### PR DESCRIPTION
## Summary
- Pass `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` secret to docker compose for web-app build
- Add 10-minute timeout to API tests step
- Add 10-minute timeout to E2E tests step

## Problem
E2E tests were hanging in CI because:
1. The web-app was built without the Mapbox token, causing map-related tests to fail/hang
2. No step-level timeouts meant hanging tests would run until the 30-minute job timeout

## Test plan
- [x] Add `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` secret to the repository
- [x] Verify E2E tests complete successfully
- [ ] Verify timeouts work if a test hangs

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)