### PR TITLE
fix(ci): use xvfb for E2E tests to enable Firefox WebGL

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Run E2E tests
         timeout-minutes: 10
-        run: npm run test:e2e
+        run: xvfb-run npm run test:e2e
         env:
           BASE_URL: http://localhost:3000
           API_URL: http://localhost:8080/api/v1


### PR DESCRIPTION
## Summary

- Wrap E2E test step with `xvfb-run` to provide a virtual display server for Firefox headless mode

Fixes #11

## Problem

All 8 Firefox E2E tests fail because Firefox headless mode [does not support WebGL](https://bugzilla.mozilla.org/show_bug.cgi?id=1375585). Mapbox GL requires WebGL to initialize, so the map never loads, bounds are never set, and the video list query never runs (`enabled: !!bounds`). Chromium and WebKit are unaffected.

## Solution

`xvfb-run` gives Firefox a virtual X11 display so it can use WebGL, matching the behavior of Chromium and WebKit headless modes. This is the [standard workaround](https://github.com/microsoft/playwright/issues/21783) for this Firefox limitation.

## Test plan

- [ ] CI passes with all 3 browsers (Chromium, Firefox, WebKit)
- [ ] The 8 previously failing Firefox tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)