### PR TITLE
feat: add bbox filter and map panning tests

### DIFF
--- a/api/tests/search-service.spec.ts
+++ b/api/tests/search-service.spec.ts
@@ -90,6 +90,57 @@ test.describe('Search Service API', () => {
       expect(body.pagination.size).toBe(10);
     });
 
+    test('supports bbox filter', async ({ request }) => {
+      // SF Bay Area bounding box: should match ~5 CA seed videos
+      const response = await request.get(`${API_URL}/search`, {
+        params: {
+          bbox: '-123,37,-121,38',
+        },
+      });
+
+      expect(response.ok()).toBeTruthy();
+      const body = await response.json();
+
+      expect(body.results).toBeInstanceOf(Array);
+      expect(body.results.length).toBeGreaterThan(0);
+      expect(body.results.length).toBeLessThanOrEqual(5);
+      // All results should have coordinates within the bbox
+      for (const result of body.results) {
+        if (result.locations.length > 0 && result.locations[0].coordinates) {
+          const { latitude, longitude } = result.locations[0].coordinates;
+          expect(latitude).toBeGreaterThanOrEqual(37);
+          expect(latitude).toBeLessThanOrEqual(38);
+          expect(longitude).toBeGreaterThanOrEqual(-123);
+          expect(longitude).toBeLessThanOrEqual(-121);
+        }
+      }
+    });
+
+    test('bbox combined with other filters narrows results', async ({ request }) => {
+      // SF Bay Area bbox + FOURTH amendment filter
+      const bboxOnly = await request.get(`${API_URL}/search`, {
+        params: {
+          bbox: '-123,37,-121,38',
+        },
+      });
+      const bboxBody = await bboxOnly.json();
+
+      const bboxPlusAmendment = await request.get(`${API_URL}/search`, {
+        params: {
+          bbox: '-123,37,-121,38',
+          amendments: 'FOURTH',
+        },
+      });
+      const combinedBody = await bboxPlusAmendment.json();
+
+      expect(bboxPlusAmendment.ok()).toBeTruthy();
+      expect(combinedBody.results.length).toBeLessThanOrEqual(bboxBody.results.length);
+      // All combined results should have FOURTH amendment
+      for (const result of combinedBody.results) {
+        expect(result.amendments).toContain('FOURTH');
+      }
+    });
+
     test('supports multiple filters combined', async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {


### PR DESCRIPTION
## Summary
- Add API integration tests for search-service bbox geographic filtering
- Add E2E test verifying map panning updates the video list based on visible area

### API tests added:
- `supports bbox filter` — verifies SF Bay Area bbox returns only CA videos with correct coordinates
- `bbox combined with other filters` — verifies bbox + amendments filter narrows results

### E2E test added:
- `panning map updates video list based on visible area` — searches for San Antonio, waits for flyTo + debounce, verifies video count decreases from initial full-US view

## Dependencies
- **Merge search-service PR first**: https://github.com/kelleyglenn/AcctAtlas-search-service/pull/11

## Test plan
- [ ] Merge search-service bbox PR and wait for CI green
- [ ] Then merge this PR and verify full integration CI passes
- [ ] Existing E2E tests should be unaffected (map starts at zoom 4 covering all 10 seed videos)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)