### PR TITLE
ci: publish test reports in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,10 @@ on:
     branches: [master, main]
   workflow_dispatch:
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest
@@ -155,6 +159,14 @@ jobs:
           path: api/test-results/
           retention-days: 14
 
+      - name: API Test Report
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: API Test Results
+          path: api/results.xml
+          reporter: java-junit
+
       - name: Run E2E tests
         timeout-minutes: 10
         run: xvfb-run npm run test:e2e
@@ -177,6 +189,14 @@ jobs:
           name: e2e-test-results
           path: e2e/test-results/
           retention-days: 14
+
+      - name: E2E Test Report
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: E2E Test Results
+          path: e2e/results.xml
+          reporter: java-junit
 
       - name: Stop services
         if: always()

--- a/api/playwright.config.ts
+++ b/api/playwright.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['github'],
+    ['junit', { outputFile: 'results.xml' }],
   ],
 
   use: {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['github'],
+    ['junit', { outputFile: 'results.xml' }],
   ],
 
   use: {


### PR DESCRIPTION
## Summary
- Add JUnit reporter to API and E2E Playwright configs
- Add test result annotations via dorny/test-reporter for both API and E2E test suites
- Test results appear as GitHub check annotations on PRs

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)