### PR TITLE
test: add E2E tests for mini-map, location link, and zoom-out clustering

### DIFF
--- a/e2e/fixtures/seed-data.ts
+++ b/e2e/fixtures/seed-data.ts
@@ -14,6 +14,8 @@ export const SEED_VIDEOS = {
     participants: ['POLICE', 'GOVERNMENT'],
     city: 'San Francisco',
     state: 'CA',
+    lat: 37.7793,
+    lng: -122.4193,
   },
   OAKLAND_MULTI_AMENDMENT: {
     id: '10000000-0000-0000-0000-000000000002',


### PR DESCRIPTION
## Summary
- Add `lat`/`lng` coordinates to `SF_FIRST_AMENDMENT` seed data fixture
- Add test verifying mini-map renders with WebGL on video detail page
- Add test clicking location link and verifying map loads with individual markers at zoom 14
- Add test navigating from zoom 14 (individual markers) to zoom 4 (clusters) to verify zoom-out clustering

## Test plan
- [x] All 3 new tests pass across Chromium, Firefox, and WebKit (59 passed, 1 pre-existing flaky)
- [x] All existing tests still pass (no regressions)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)