### PR TITLE
test: add SECURITY participant filter test

### DIFF
--- a/api/tests/search-service.spec.ts
+++ b/api/tests/search-service.spec.ts
@@ -62,6 +62,23 @@ test.describe('Search Service API', () => {
       }
     });
 
+    test('supports SECURITY participant filter', async ({ request }) => {
+      const response = await request.get(`${API_URL}/search`, {
+        params: {
+          participants: 'SECURITY',
+        },
+      });
+
+      expect(response.ok()).toBeTruthy();
+      const body = await response.json();
+
+      expect(body.results).toBeInstanceOf(Array);
+      // All results should have SECURITY participant if any exist
+      for (const result of body.results) {
+        expect(result.participants).toContain('SECURITY');
+      }
+    });
+
     test('supports state filter', async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {

--- a/e2e/fixtures/seed-data.ts
+++ b/e2e/fixtures/seed-data.ts
@@ -44,6 +44,15 @@ export const SEED_VIDEOS = {
     city: 'Silverthorne',
     state: 'CO',
   },
+  UTICA_SECURITY: {
+    id: '10000000-0000-0000-0000-000000000004',
+    youtubeId: 'AJi0LgnoIJA',
+    title: 'Utica Michigan Police Confrontation',
+    amendments: ['FIRST', 'FOURTH'],
+    participants: ['POLICE', 'SECURITY'],
+    city: 'Fremont',
+    state: 'CA',
+  },
 } as const;
 
 /** Known user IDs from dev seed data */


### PR DESCRIPTION
## Summary
- Add `UTICA_SECURITY` seed data entry for Video 4 (now has SECURITY participant)
- Add API test verifying `participants=SECURITY` filter works end-to-end

Closes #34

Part of cross-cutting change: [AccountabilityAtlas#46](https://github.com/kelleyglenn/AccountabilityAtlas/issues/46)

Depends on (all merged):
- kelleyglenn/AcctAtlas-video-service#42
- kelleyglenn/AcctAtlas-search-service#24
- kelleyglenn/AcctAtlas-moderation-service#26
- kelleyglenn/AcctAtlas-web-app#51

## Test plan
- [x] `npm run test:all` passes (107 API + 138 E2E tests)
- [x] New SECURITY filter test returns correct results from deployed stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)