### PR TITLE
test: add E2E tests for hero landing page

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: "temurin"
+          java-version: "21"
 
       - name: Build user-service image
         working-directory: infra/AcctAtlas-user-service
@@ -125,7 +125,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ End-to-end and API integration tests for [AccountabilityAtlas](https://github.co
 
 ## Test Types
 
-| Type | Location | Purpose | Status |
-|------|----------|---------|--------|
-| E2E | `e2e/` | Full browser-to-database user journeys | Active |
-| API | `api/` | Service contract validation | Active |
+| Type | Location | Purpose                                | Status |
+| ---- | -------- | -------------------------------------- | ------ |
+| E2E  | `e2e/`   | Full browser-to-database user journeys | Active |
+| API  | `api/`   | Service contract validation            | Active |
 
 ## Technology Stack
 
@@ -15,6 +15,7 @@ End-to-end and API integration tests for [AccountabilityAtlas](https://github.co
 - **Language:** TypeScript
 - **Browsers:** Chromium, Firefox, WebKit (E2E only)
 - **Linting:** ESLint with [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright)
+- **Formatting:** [Prettier](https://prettier.io/)
 - **CI:** GitHub Actions
 
 ## Prerequisites
@@ -49,12 +50,17 @@ npm run test:e2e:debug        # Run with debugger
 npm run test:api:debug        # Run API tests with debugger
 ```
 
-### 3. Lint the code
+### 3. Code quality checks
 
 ```bash
+npm run check                 # Run all quality checks (format + lint)
 npm run lint                  # Check for linting errors
 npm run lint:fix              # Auto-fix linting errors
+npm run format                # Auto-format all files with Prettier
+npm run format:check          # Check formatting without modifying files
 ```
+
+> **Tip:** Run `npm run check` before pushing to catch formatting and lint issues that will fail CI.
 
 ### 4. View test reports
 
@@ -81,11 +87,13 @@ npm run test:e2e -- --project=chromium
 ## CI Behavior
 
 Tests run automatically on:
+
 - Push to `master`/`main`
 - Pull requests to `master`/`main`
 - Manual trigger via `workflow_dispatch`
 
 The CI workflow:
+
 1. Spins up the full stack via `docker-compose`
 2. Runs API tests (no browser needed)
 3. Runs E2E tests on Chromium, Firefox, and WebKit
@@ -124,16 +132,17 @@ AcctAtlas-integration-tests/
 
 Tests run in dependency order: health → user-service → other services
 
-| Service | Passing | Skipped | Coverage |
-|---------|---------|---------|----------|
-| Health | 6 | 0 | All service health endpoints |
-| User | 19 | 11 | Registration, login, profile, trust tiers |
-| Location | 9 | 1 | CRUD, spatial queries, clustering |
-| Video | 14 | 0 | CRUD, access control, locations |
-| Moderation | 5 | 0 | Queue access, abuse reports |
-| Search | 8 | 0 | Filters, pagination, public access |
+| Service    | Passing | Skipped | Coverage                                  |
+| ---------- | ------- | ------- | ----------------------------------------- |
+| Health     | 6       | 0       | All service health endpoints              |
+| User       | 19      | 11      | Registration, login, profile, trust tiers |
+| Location   | 9       | 1       | CRUD, spatial queries, clustering         |
+| Video      | 14      | 0       | CRUD, access control, locations           |
+| Moderation | 5       | 0       | Queue access, abuse reports               |
+| Search     | 8       | 0       | Filters, pagination, public access        |
 
 **Skipped tests** are for unimplemented endpoints:
+
 - Token refresh ([#22](https://github.com/kelleyglenn/AcctAtlas-user-service/issues/22))
 - Logout ([#23](https://github.com/kelleyglenn/AcctAtlas-user-service/issues/23))
 - Profile update ([#24](https://github.com/kelleyglenn/AcctAtlas-user-service/issues/24))
@@ -142,11 +151,11 @@ Tests run in dependency order: health → user-service → other services
 
 ### E2E Tests (16 test cases × 3 browsers = 48 test runs)
 
-| Feature | Test Cases | Coverage |
-|---------|------------|----------|
-| Auth | 3 | Login flow (valid/invalid credentials, accessibility) |
-| Map | 7 | Map browsing, markers, filters, search, list interaction |
-| Video | 6 | Video detail page, navigation, YouTube link, 404 |
+| Feature | Test Cases | Coverage                                                 |
+| ------- | ---------- | -------------------------------------------------------- |
+| Auth    | 3          | Login flow (valid/invalid credentials, accessibility)    |
+| Map     | 7          | Map browsing, markers, filters, search, list interaction |
+| Video   | 6          | Video detail page, navigation, YouTube link, 404         |
 
 Tests run on Chromium, Firefox, and WebKit browsers.
 
@@ -157,14 +166,15 @@ See the [Playwright documentation](https://playwright.dev/docs/writing-tests) fo
 ### API Test Patterns
 
 **Using test helpers:**
-```typescript
-import { createTestUser, authHeaders } from '../fixtures/api-helpers';
 
-test('creates a resource', async ({ request }) => {
+```typescript
+import { createTestUser, authHeaders } from "../fixtures/api-helpers";
+
+test("creates a resource", async ({ request }) => {
   const user = await createTestUser(request);
 
   const response = await request.post(`${API_URL}/resources`, {
-    data: { name: 'Test' },
+    data: { name: "Test" },
     headers: authHeaders(user.accessToken),
   });
 
@@ -175,22 +185,25 @@ test('creates a resource', async ({ request }) => {
 ### E2E Test Patterns
 
 **Semantic locators** (layout-resilient):
+
 ```typescript
-await page.getByLabel('Email').fill('test@example.com');
-await page.getByRole('button', { name: /log in/i }).click();
+await page.getByLabel("Email").fill("test@example.com");
+await page.getByRole("button", { name: /log in/i }).click();
 ```
 
 **API-based test setup**:
-```typescript
-import { createTestUser } from '../../fixtures/test-data';
 
-test('example', async ({ page, request }) => {
+```typescript
+import { createTestUser } from "../../fixtures/test-data";
+
+test("example", async ({ page, request }) => {
   const user = await createTestUser(request);
   // ... test with the created user
 });
 ```
 
 **SQL seeds for edge cases**:
+
 ```typescript
 // For states not creatable via API (e.g., moderator users)
 // Run SQL seed before tests, then use known credentials

--- a/api/playwright.config.ts
+++ b/api/playwright.config.ts
@@ -1,21 +1,21 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: [
-    ['html', { outputFolder: 'playwright-report' }],
-    ['github'],
-    ['junit', { outputFile: 'results.xml' }],
+    ["html", { outputFolder: "playwright-report" }],
+    ["github"],
+    ["junit", { outputFile: "results.xml" }],
   ],
 
   use: {
-    baseURL: process.env.API_URL || 'http://localhost:8080/api/v1',
+    baseURL: process.env.API_URL || "http://localhost:8080/api/v1",
     extraHTTPHeaders: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     },
   },
 
@@ -23,20 +23,20 @@ export default defineConfig({
   // Health checks run first to verify services are up, then user-service, then others
   projects: [
     {
-      name: 'health',
+      name: "health",
       testMatch: /health\.spec\.ts/,
     },
     {
-      name: 'user-service',
+      name: "user-service",
       testMatch: /user-service\.spec\.ts/,
-      dependencies: ['health'],
+      dependencies: ["health"],
     },
     {
-      name: 'other-services',
+      name: "other-services",
       testIgnore: [/health\.spec\.ts/, /user-service\.spec\.ts/],
-      dependencies: ['user-service'],
+      dependencies: ["user-service"],
     },
   ],
 
-  outputDir: 'test-results',
+  outputDir: "test-results",
 });

--- a/api/tests/health.spec.ts
+++ b/api/tests/health.spec.ts
@@ -1,23 +1,25 @@
-import { test, expect } from '@playwright/test';
-import { SERVICE_HOST } from '../fixtures/api-helpers.js';
+import { test, expect } from "@playwright/test";
+import { SERVICE_HOST } from "../fixtures/api-helpers.js";
 
 const SERVICES = [
-  { name: 'api-gateway', port: 8080 },
-  { name: 'user-service', port: 8081 },
-  { name: 'video-service', port: 8082 },
-  { name: 'location-service', port: 8083 },
-  { name: 'search-service', port: 8084 },
-  { name: 'moderation-service', port: 8085 },
+  { name: "api-gateway", port: 8080 },
+  { name: "user-service", port: 8081 },
+  { name: "video-service", port: 8082 },
+  { name: "location-service", port: 8083 },
+  { name: "search-service", port: 8084 },
+  { name: "moderation-service", port: 8085 },
 ];
 
-test.describe('Service Health Checks', () => {
+test.describe("Service Health Checks", () => {
   for (const service of SERVICES) {
     test(`${service.name} is healthy`, async ({ request }) => {
-      const response = await request.get(`http://${SERVICE_HOST}:${service.port}/actuator/health`);
+      const response = await request.get(
+        `http://${SERVICE_HOST}:${service.port}/actuator/health`,
+      );
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
-      expect(body.status).toBe('UP');
+      expect(body.status).toBe("UP");
     });
   }
 });

--- a/api/tests/jwt-cross-service.spec.ts
+++ b/api/tests/jwt-cross-service.spec.ts
@@ -1,12 +1,18 @@
-import { test, expect } from '@playwright/test';
-import { API_URL, SERVICE_HOST, createTestUser, authHeaders } from '../fixtures/api-helpers.js';
+import { test, expect } from "@playwright/test";
+import {
+  API_URL,
+  SERVICE_HOST,
+  createTestUser,
+  authHeaders,
+} from "../fixtures/api-helpers.js";
 
-test.describe('JWKS and Cross-Service JWT', () => {
-
-  test.describe('JWKS Endpoint', () => {
-    test('user-service exposes valid JWKS endpoint', async ({ request }) => {
+test.describe("JWKS and Cross-Service JWT", () => {
+  test.describe("JWKS Endpoint", () => {
+    test("user-service exposes valid JWKS endpoint", async ({ request }) => {
       // Direct call to user-service (not through gateway)
-      const response = await request.get(`http://${SERVICE_HOST}:8081/.well-known/jwks.json`);
+      const response = await request.get(
+        `http://${SERVICE_HOST}:8081/.well-known/jwks.json`,
+      );
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
@@ -16,23 +22,31 @@ test.describe('JWKS and Cross-Service JWT', () => {
       expect(body.keys.length).toBeGreaterThan(0);
 
       const key = body.keys[0];
-      expect(key.kty).toBe('RSA');
-      expect(key.kid).toBe('user-service-key-1');
+      expect(key.kty).toBe("RSA");
+      expect(key.kid).toBe("user-service-key-1");
       expect(key.n).toBeDefined();
       expect(key.e).toBeDefined();
     });
 
-    test('JWKS endpoint does not require authentication', async ({ request }) => {
+    test("JWKS endpoint does not require authentication", async ({
+      request,
+    }) => {
       // No Authorization header
-      const response = await request.get(`http://${SERVICE_HOST}:8081/.well-known/jwks.json`);
+      const response = await request.get(
+        `http://${SERVICE_HOST}:8081/.well-known/jwks.json`,
+      );
       expect(response.ok()).toBeTruthy();
       expect(response.status()).not.toBe(401);
       expect(response.status()).not.toBe(403);
     });
 
-    test('JWKS endpoint returns consistent keys', async ({ request }) => {
-      const response1 = await request.get(`http://${SERVICE_HOST}:8081/.well-known/jwks.json`);
-      const response2 = await request.get(`http://${SERVICE_HOST}:8081/.well-known/jwks.json`);
+    test("JWKS endpoint returns consistent keys", async ({ request }) => {
+      const response1 = await request.get(
+        `http://${SERVICE_HOST}:8081/.well-known/jwks.json`,
+      );
+      const response2 = await request.get(
+        `http://${SERVICE_HOST}:8081/.well-known/jwks.json`,
+      );
 
       const body1 = await response1.json();
       const body2 = await response2.json();
@@ -42,8 +56,10 @@ test.describe('JWKS and Cross-Service JWT', () => {
     });
   });
 
-  test.describe('Cross-Service JWT Validation', () => {
-    test('video-service accepts JWT issued by user-service', async ({ request }) => {
+  test.describe("Cross-Service JWT Validation", () => {
+    test("video-service accepts JWT issued by user-service", async ({
+      request,
+    }) => {
       // Get a real JWT from user-service via registration
       const user = await createTestUser(request);
 
@@ -57,13 +73,15 @@ test.describe('JWKS and Cross-Service JWT', () => {
       expect(body.content).toBeInstanceOf(Array);
     });
 
-    test('video-service accepts JWT for authenticated operations', async ({ request }) => {
+    test("video-service accepts JWT for authenticated operations", async ({
+      request,
+    }) => {
       // Get a real JWT from user-service
       const user = await createTestUser(request);
 
       // Use that token to hit an authenticated preview endpoint
       const response = await request.get(`${API_URL}/videos/preview`, {
-        params: { youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+        params: { youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
         headers: authHeaders(user.accessToken),
       });
 
@@ -72,11 +90,13 @@ test.describe('JWKS and Cross-Service JWT', () => {
     });
   });
 
-  test.describe('Lenient JWT Handling', () => {
-    test('public GET endpoint returns 200 with invalid Bearer token', async ({ request }) => {
+  test.describe("Lenient JWT Handling", () => {
+    test("public GET endpoint returns 200 with invalid Bearer token", async ({
+      request,
+    }) => {
       // Send invalid token to a public endpoint
       const response = await request.get(`${API_URL}/videos`, {
-        headers: { Authorization: 'Bearer definitely-not-a-valid-jwt-token' },
+        headers: { Authorization: "Bearer definitely-not-a-valid-jwt-token" },
       });
 
       // Should return 200 (lenient), NOT 401
@@ -84,35 +104,44 @@ test.describe('JWKS and Cross-Service JWT', () => {
       expect(response.status()).toBe(200);
     });
 
-    test('public GET endpoint returns 200 with expired-format token', async ({ request }) => {
+    test("public GET endpoint returns 200 with expired-format token", async ({
+      request,
+    }) => {
       // A JWT-like but invalid token
       const response = await request.get(`${API_URL}/videos`, {
-        headers: { Authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmYWtlIn0.invalid' },
+        headers: {
+          Authorization:
+            "Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmYWtlIn0.invalid",
+        },
       });
 
       // Should return 200 (lenient), NOT 401
       expect(response.ok()).toBeTruthy();
     });
 
-    test('protected POST endpoint rejects invalid token', async ({ request }) => {
+    test("protected POST endpoint rejects invalid token", async ({
+      request,
+    }) => {
       const response = await request.post(`${API_URL}/videos`, {
         data: {
-          youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-          amendments: ['FIRST'],
-          participants: ['POLICE'],
-          locationId: '00000000-0000-0000-0000-000000000000',
+          youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          amendments: ["FIRST"],
+          participants: ["POLICE"],
+          locationId: "00000000-0000-0000-0000-000000000000",
         },
-        headers: { Authorization: 'Bearer invalid-token' },
+        headers: { Authorization: "Bearer invalid-token" },
       });
 
       // Should get 401 or 403, NOT 200 or 500
       expect([401, 403]).toContain(response.status());
     });
 
-    test('preview endpoint works with invalid token (lenient)', async ({ request }) => {
+    test("preview endpoint works with invalid token (lenient)", async ({
+      request,
+    }) => {
       const response = await request.get(`${API_URL}/videos/preview`, {
-        params: { youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
-        headers: { Authorization: 'Bearer invalid-token' },
+        params: { youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
+        headers: { Authorization: "Bearer invalid-token" },
       });
 
       // Preview is public, so should still work even with invalid token.

--- a/api/tests/moderation-service.spec.ts
+++ b/api/tests/moderation-service.spec.ts
@@ -1,16 +1,20 @@
-import { test, expect } from '@playwright/test';
-import { API_URL, createTestUser, authHeaders } from '../fixtures/api-helpers.js';
+import { test, expect } from "@playwright/test";
+import {
+  API_URL,
+  createTestUser,
+  authHeaders,
+} from "../fixtures/api-helpers.js";
 
-test.describe('Moderation Service API', () => {
-  test.describe('Queue Access Control', () => {
-    test('requires authentication to access queue', async ({ request }) => {
+test.describe("Moderation Service API", () => {
+  test.describe("Queue Access Control", () => {
+    test("requires authentication to access queue", async ({ request }) => {
       const response = await request.get(`${API_URL}/moderation/queue`);
 
       // Should return 401 or 403 without auth
       expect([401, 403]).toContain(response.status());
     });
 
-    test('requires moderator role to access queue', async ({ request }) => {
+    test("requires moderator role to access queue", async ({ request }) => {
       // Create a regular user (NEW trust tier)
       const user = await createTestUser(request);
 
@@ -23,8 +27,8 @@ test.describe('Moderation Service API', () => {
     });
   });
 
-  test.describe('Queue Stats', () => {
-    test('requires moderator role for stats', async ({ request }) => {
+  test.describe("Queue Stats", () => {
+    test("requires moderator role for stats", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.get(`${API_URL}/moderation/queue/stats`, {
@@ -35,20 +39,20 @@ test.describe('Moderation Service API', () => {
     });
   });
 
-  test.describe('Abuse Reports', () => {
-    test('requires authentication to submit report', async ({ request }) => {
+  test.describe("Abuse Reports", () => {
+    test("requires authentication to submit report", async ({ request }) => {
       const response = await request.post(`${API_URL}/moderation/reports`, {
         data: {
-          contentType: 'VIDEO',
-          contentId: '00000000-0000-0000-0000-000000000000',
-          reason: 'SPAM',
+          contentType: "VIDEO",
+          contentId: "00000000-0000-0000-0000-000000000000",
+          reason: "SPAM",
         },
       });
 
       expect([401, 403]).toContain(response.status());
     });
 
-    test('requires moderator role to list reports', async ({ request }) => {
+    test("requires moderator role to list reports", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.get(`${API_URL}/moderation/reports`, {
@@ -59,8 +63,8 @@ test.describe('Moderation Service API', () => {
     });
   });
 
-  test.describe('Queue Content Lookup', () => {
-    test('requires authentication for content lookup', async ({ request }) => {
+  test.describe("Queue Content Lookup", () => {
+    test("requires authentication for content lookup", async ({ request }) => {
       const response = await request.get(
         `${API_URL}/moderation/queue/by-content/00000000-0000-0000-0000-000000000000`,
       );
@@ -69,7 +73,7 @@ test.describe('Moderation Service API', () => {
       expect([401, 403]).toContain(response.status());
     });
 
-    test('requires moderator role for content lookup', async ({ request }) => {
+    test("requires moderator role for content lookup", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.get(

--- a/api/tests/search-service.spec.ts
+++ b/api/tests/search-service.spec.ts
@@ -1,9 +1,9 @@
-import { test, expect } from '@playwright/test';
-import { API_URL } from '../fixtures/api-helpers.js';
+import { test, expect } from "@playwright/test";
+import { API_URL } from "../fixtures/api-helpers.js";
 
-test.describe('Search Service API', () => {
-  test.describe('Video Search', () => {
-    test('returns empty results when no videos exist', async ({ request }) => {
+test.describe("Search Service API", () => {
+  test.describe("Video Search", () => {
+    test("returns empty results when no videos exist", async ({ request }) => {
       const response = await request.get(`${API_URL}/search`);
 
       expect(response.ok()).toBeTruthy();
@@ -14,10 +14,10 @@ test.describe('Search Service API', () => {
       expect(body.pagination.totalElements).toBeGreaterThanOrEqual(0);
     });
 
-    test('supports text query search', async ({ request }) => {
+    test("supports text query search", async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {
-          q: 'police audit',
+          q: "police audit",
         },
       });
 
@@ -28,10 +28,10 @@ test.describe('Search Service API', () => {
       expect(body.pagination).toBeDefined();
     });
 
-    test('supports amendment filter', async ({ request }) => {
+    test("supports amendment filter", async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {
-          amendments: 'FIRST',
+          amendments: "FIRST",
         },
       });
 
@@ -41,14 +41,14 @@ test.describe('Search Service API', () => {
       expect(body.results).toBeInstanceOf(Array);
       // All results should have FIRST amendment if any exist
       for (const result of body.results) {
-        expect(result.amendments).toContain('FIRST');
+        expect(result.amendments).toContain("FIRST");
       }
     });
 
-    test('supports participant filter', async ({ request }) => {
+    test("supports participant filter", async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {
-          participants: 'POLICE',
+          participants: "POLICE",
         },
       });
 
@@ -58,14 +58,14 @@ test.describe('Search Service API', () => {
       expect(body.results).toBeInstanceOf(Array);
       // All results should have POLICE participant if any exist
       for (const result of body.results) {
-        expect(result.participants).toContain('POLICE');
+        expect(result.participants).toContain("POLICE");
       }
     });
 
-    test('supports SECURITY participant filter', async ({ request }) => {
+    test("supports SECURITY participant filter", async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {
-          participants: 'SECURITY',
+          participants: "SECURITY",
         },
       });
 
@@ -75,14 +75,14 @@ test.describe('Search Service API', () => {
       expect(body.results).toBeInstanceOf(Array);
       // All results should have SECURITY participant if any exist
       for (const result of body.results) {
-        expect(result.participants).toContain('SECURITY');
+        expect(result.participants).toContain("SECURITY");
       }
     });
 
-    test('supports state filter', async ({ request }) => {
+    test("supports state filter", async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {
-          state: 'AZ',
+          state: "AZ",
         },
       });
 
@@ -92,7 +92,7 @@ test.describe('Search Service API', () => {
       expect(body.results).toBeInstanceOf(Array);
     });
 
-    test('supports pagination', async ({ request }) => {
+    test("supports pagination", async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {
           page: 0,
@@ -107,11 +107,11 @@ test.describe('Search Service API', () => {
       expect(body.pagination.size).toBe(10);
     });
 
-    test('supports bbox filter', async ({ request }) => {
+    test("supports bbox filter", async ({ request }) => {
       // SF Bay Area bounding box: should match ~5 CA seed videos
       const response = await request.get(`${API_URL}/search`, {
         params: {
-          bbox: '-123,37,-121,38',
+          bbox: "-123,37,-121,38",
         },
       });
 
@@ -133,37 +133,41 @@ test.describe('Search Service API', () => {
       }
     });
 
-    test('bbox combined with other filters narrows results', async ({ request }) => {
+    test("bbox combined with other filters narrows results", async ({
+      request,
+    }) => {
       // SF Bay Area bbox + FOURTH amendment filter
       const bboxOnly = await request.get(`${API_URL}/search`, {
         params: {
-          bbox: '-123,37,-121,38',
+          bbox: "-123,37,-121,38",
         },
       });
       const bboxBody = await bboxOnly.json();
 
       const bboxPlusAmendment = await request.get(`${API_URL}/search`, {
         params: {
-          bbox: '-123,37,-121,38',
-          amendments: 'FOURTH',
+          bbox: "-123,37,-121,38",
+          amendments: "FOURTH",
         },
       });
       const combinedBody = await bboxPlusAmendment.json();
 
       expect(bboxPlusAmendment.ok()).toBeTruthy();
-      expect(combinedBody.results.length).toBeLessThanOrEqual(bboxBody.results.length);
+      expect(combinedBody.results.length).toBeLessThanOrEqual(
+        bboxBody.results.length,
+      );
       // All combined results should have FOURTH amendment
       for (const result of combinedBody.results) {
-        expect(result.amendments).toContain('FOURTH');
+        expect(result.amendments).toContain("FOURTH");
       }
     });
 
-    test('supports multiple filters combined', async ({ request }) => {
+    test("supports multiple filters combined", async ({ request }) => {
       const response = await request.get(`${API_URL}/search`, {
         params: {
-          amendments: 'FIRST',
-          participants: 'POLICE',
-          state: 'AZ',
+          amendments: "FIRST",
+          participants: "POLICE",
+          state: "AZ",
         },
       });
 
@@ -174,8 +178,8 @@ test.describe('Search Service API', () => {
     });
   });
 
-  test.describe('Search is Public', () => {
-    test('does not require authentication', async ({ request }) => {
+  test.describe("Search is Public", () => {
+    test("does not require authentication", async ({ request }) => {
       // Search should work without auth header
       const response = await request.get(`${API_URL}/search`);
 

--- a/api/tests/user-service.spec.ts
+++ b/api/tests/user-service.spec.ts
@@ -1,13 +1,17 @@
-import { test, expect } from '@playwright/test';
-import { API_URL, createTestUser, authHeaders } from '../fixtures/api-helpers.js';
+import { test, expect } from "@playwright/test";
+import {
+  API_URL,
+  createTestUser,
+  authHeaders,
+} from "../fixtures/api-helpers.js";
 
-test.describe('User Service API', () => {
-  test.describe('Registration', () => {
-    test('registers a new user with valid data', async ({ request }) => {
+test.describe("User Service API", () => {
+  test.describe("Registration", () => {
+    test("registers a new user with valid data", async ({ request }) => {
       const userData = {
         email: `register-test-${Date.now()}@example.com`,
-        password: 'TestPass123!',
-        displayName: 'Registration Test User',
+        password: "TestPass123!",
+        displayName: "Registration Test User",
       };
 
       const response = await request.post(`${API_URL}/auth/register`, {
@@ -22,7 +26,7 @@ test.describe('User Service API', () => {
       expect(body.user.id).toBeDefined();
       expect(body.user.email).toBe(userData.email);
       expect(body.user.displayName).toBe(userData.displayName);
-      expect(body.user.trustTier).toBe('NEW');
+      expect(body.user.trustTier).toBe("NEW");
       expect(body.user.emailVerified).toBe(false);
 
       expect(body.tokens).toBeDefined();
@@ -31,21 +35,21 @@ test.describe('User Service API', () => {
       expect(body.tokens.expiresIn).toBeGreaterThan(0);
     });
 
-    test('rejects registration with duplicate email', async ({ request }) => {
+    test("rejects registration with duplicate email", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.post(`${API_URL}/auth/register`, {
         data: {
           email: user.email,
-          password: 'AnotherPass123!',
-          displayName: 'Duplicate User',
+          password: "AnotherPass123!",
+          displayName: "Duplicate User",
         },
       });
 
       expect(response.status()).toBe(409);
     });
 
-    test('validates required fields', async ({ request }) => {
+    test("validates required fields", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/register`, {
         data: {
           // Missing all required fields
@@ -55,36 +59,36 @@ test.describe('User Service API', () => {
       expect(response.status()).toBe(400);
     });
 
-    test('validates email format', async ({ request }) => {
+    test("validates email format", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/register`, {
         data: {
-          email: 'not-an-email',
-          password: 'TestPass123!',
-          displayName: 'Test User',
+          email: "not-an-email",
+          password: "TestPass123!",
+          displayName: "Test User",
         },
       });
 
       expect(response.status()).toBe(400);
     });
 
-    test('validates password strength', async ({ request }) => {
+    test("validates password strength", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/register`, {
         data: {
           email: `weak-pass-${Date.now()}@example.com`,
-          password: 'weak', // Too short, missing requirements
-          displayName: 'Test User',
+          password: "weak", // Too short, missing requirements
+          displayName: "Test User",
         },
       });
 
       expect(response.status()).toBe(400);
     });
 
-    test('validates display name length', async ({ request }) => {
+    test("validates display name length", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/register`, {
         data: {
           email: `short-name-${Date.now()}@example.com`,
-          password: 'TestPass123!',
-          displayName: 'X', // Too short (min 2 chars)
+          password: "TestPass123!",
+          displayName: "X", // Too short (min 2 chars)
         },
       });
 
@@ -92,8 +96,8 @@ test.describe('User Service API', () => {
     });
   });
 
-  test.describe('Login', () => {
-    test('logs in with valid credentials', async ({ request }) => {
+  test.describe("Login", () => {
+    test("logs in with valid credentials", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.post(`${API_URL}/auth/login`, {
@@ -115,31 +119,31 @@ test.describe('User Service API', () => {
       expect(body.tokens.refreshToken).toBeDefined();
     });
 
-    test('rejects invalid password', async ({ request }) => {
+    test("rejects invalid password", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.post(`${API_URL}/auth/login`, {
         data: {
           email: user.email,
-          password: 'WrongPassword123!',
+          password: "WrongPassword123!",
         },
       });
 
       expect(response.status()).toBe(401);
     });
 
-    test('rejects non-existent email', async ({ request }) => {
+    test("rejects non-existent email", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/login`, {
         data: {
           email: `nonexistent-${Date.now()}@example.com`,
-          password: 'TestPass123!',
+          password: "TestPass123!",
         },
       });
 
       expect(response.status()).toBe(401);
     });
 
-    test('validates required fields', async ({ request }) => {
+    test("validates required fields", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/login`, {
         data: {
           // Missing email and password
@@ -150,15 +154,17 @@ test.describe('User Service API', () => {
     });
   });
 
-  test.describe('Token Refresh', () => {
+  test.describe("Token Refresh", () => {
     // TODO: Token refresh endpoint not yet implemented
     // See: https://github.com/kelleyglenn/AcctAtlas-user-service/issues/22
-    test.skip('refreshes tokens with valid refresh token', async ({ request }) => {
+    test.skip("refreshes tokens with valid refresh token", async ({
+      request,
+    }) => {
       // Register to get initial tokens
       const userData = {
         email: `refresh-test-${Date.now()}@example.com`,
-        password: 'TestPass123!',
-        displayName: 'Refresh Test User',
+        password: "TestPass123!",
+        displayName: "Refresh Test User",
       };
 
       const registerResponse = await request.post(`${API_URL}/auth/register`, {
@@ -185,10 +191,10 @@ test.describe('User Service API', () => {
 
     // TODO: Token refresh endpoint not yet implemented
     // See: https://github.com/kelleyglenn/AcctAtlas-user-service/issues/22
-    test.skip('rejects invalid refresh token', async ({ request }) => {
+    test.skip("rejects invalid refresh token", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/refresh`, {
         data: {
-          refreshToken: 'invalid-refresh-token',
+          refreshToken: "invalid-refresh-token",
         },
       });
 
@@ -197,12 +203,12 @@ test.describe('User Service API', () => {
 
     // TODO: Token refresh endpoint not yet implemented
     // See: https://github.com/kelleyglenn/AcctAtlas-user-service/issues/22
-    test.skip('rejects reused refresh token', async ({ request }) => {
+    test.skip("rejects reused refresh token", async ({ request }) => {
       // Register to get initial tokens
       const userData = {
         email: `reuse-test-${Date.now()}@example.com`,
-        password: 'TestPass123!',
-        displayName: 'Reuse Test User',
+        password: "TestPass123!",
+        displayName: "Reuse Test User",
       };
 
       const registerResponse = await request.post(`${API_URL}/auth/register`, {
@@ -225,14 +231,14 @@ test.describe('User Service API', () => {
     });
   });
 
-  test.describe('Logout', () => {
-    test('requires authentication', async ({ request }) => {
+  test.describe("Logout", () => {
+    test("requires authentication", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/logout`);
 
       expect([401, 403]).toContain(response.status());
     });
 
-    test('logs out authenticated user', async ({ request }) => {
+    test("logs out authenticated user", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.post(`${API_URL}/auth/logout`, {
@@ -243,14 +249,14 @@ test.describe('User Service API', () => {
     });
   });
 
-  test.describe('Get Current User Profile', () => {
-    test('requires authentication', async ({ request }) => {
+  test.describe("Get Current User Profile", () => {
+    test("requires authentication", async ({ request }) => {
       const response = await request.get(`${API_URL}/users/me`);
 
       expect([401, 403]).toContain(response.status());
     });
 
-    test('returns current user profile', async ({ request }) => {
+    test("returns current user profile", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.get(`${API_URL}/users/me`, {
@@ -263,19 +269,19 @@ test.describe('User Service API', () => {
       expect(body.id).toBe(user.id);
       expect(body.email).toBe(user.email);
       expect(body.displayName).toBe(user.displayName);
-      expect(body.trustTier).toBe('NEW');
+      expect(body.trustTier).toBe("NEW");
     });
   });
 
-  test.describe('Update Current User Profile', () => {
-    test('requires authentication', async ({ request }) => {
+  test.describe("Update Current User Profile", () => {
+    test("requires authentication", async ({ request }) => {
       const response = await request.put(`${API_URL}/users/me`, {
-        data: { displayName: 'Updated Name' },
+        data: { displayName: "Updated Name" },
       });
       expect([401, 403]).toContain(response.status());
     });
 
-    test('updates display name', async ({ request }) => {
+    test("updates display name", async ({ request }) => {
       const user = await createTestUser(request);
       const newName = `Updated ${Date.now()}`;
 
@@ -289,52 +295,54 @@ test.describe('User Service API', () => {
       expect(body.displayName).toBe(newName);
     });
 
-    test('updates avatar URL', async ({ request }) => {
+    test("updates avatar URL", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.put(`${API_URL}/users/me`, {
-        data: { avatarUrl: 'https://gravatar.com/avatar/test123' },
+        data: { avatarUrl: "https://gravatar.com/avatar/test123" },
         headers: authHeaders(user.accessToken),
       });
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
-      expect(body.avatarUrl).toBe('https://gravatar.com/avatar/test123');
+      expect(body.avatarUrl).toBe("https://gravatar.com/avatar/test123");
     });
 
-    test('supports partial updates (preserves other fields)', async ({ request }) => {
+    test("supports partial updates (preserves other fields)", async ({
+      request,
+    }) => {
       const user = await createTestUser(request);
 
       const response = await request.put(`${API_URL}/users/me`, {
-        data: { displayName: 'Partial Update' },
+        data: { displayName: "Partial Update" },
         headers: authHeaders(user.accessToken),
       });
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
-      expect(body.displayName).toBe('Partial Update');
+      expect(body.displayName).toBe("Partial Update");
       expect(body.email).toBe(user.email); // Unchanged
     });
 
-    test('validates display name minimum length', async ({ request }) => {
+    test("validates display name minimum length", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.put(`${API_URL}/users/me`, {
-        data: { displayName: 'X' }, // Too short (min 2)
+        data: { displayName: "X" }, // Too short (min 2)
         headers: authHeaders(user.accessToken),
       });
 
       expect(response.status()).toBe(400);
     });
 
-    test('updates social links', async ({ request }) => {
+    test("updates social links", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.put(`${API_URL}/users/me`, {
         data: {
           socialLinks: {
-            youtube: 'UCtest123',
-            instagram: 'testhandle',
+            youtube: "UCtest123",
+            instagram: "testhandle",
           },
         },
         headers: authHeaders(user.accessToken),
@@ -342,18 +350,18 @@ test.describe('User Service API', () => {
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
-      expect(body.socialLinks.youtube).toBe('UCtest123');
-      expect(body.socialLinks.instagram).toBe('testhandle');
+      expect(body.socialLinks.youtube).toBe("UCtest123");
+      expect(body.socialLinks.instagram).toBe("testhandle");
     });
 
-    test('updates privacy settings', async ({ request }) => {
+    test("updates privacy settings", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.put(`${API_URL}/users/me`, {
         data: {
           privacySettings: {
-            socialLinksVisibility: 'PUBLIC',
-            submissionsVisibility: 'REGISTERED',
+            socialLinksVisibility: "PUBLIC",
+            submissionsVisibility: "REGISTERED",
           },
         },
         headers: authHeaders(user.accessToken),
@@ -361,22 +369,24 @@ test.describe('User Service API', () => {
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
-      expect(body.privacySettings.socialLinksVisibility).toBe('PUBLIC');
-      expect(body.privacySettings.submissionsVisibility).toBe('REGISTERED');
+      expect(body.privacySettings.socialLinksVisibility).toBe("PUBLIC");
+      expect(body.privacySettings.submissionsVisibility).toBe("REGISTERED");
     });
 
-    test('clears social link field when updated to empty string', async ({ request }) => {
+    test("clears social link field when updated to empty string", async ({
+      request,
+    }) => {
       const user = await createTestUser(request);
 
       // Set initial value
       await request.put(`${API_URL}/users/me`, {
-        data: { socialLinks: { youtube: 'UCtest123' } },
+        data: { socialLinks: { youtube: "UCtest123" } },
         headers: authHeaders(user.accessToken),
       });
 
       // Clear it by sending empty string
       const response = await request.put(`${API_URL}/users/me`, {
-        data: { socialLinks: { youtube: '' } },
+        data: { socialLinks: { youtube: "" } },
         headers: authHeaders(user.accessToken),
       });
 
@@ -385,29 +395,33 @@ test.describe('User Service API', () => {
       expect(body.socialLinks?.youtube).toBeUndefined();
     });
 
-    test('returns field-level validation errors for invalid input', async ({ request }) => {
+    test("returns field-level validation errors for invalid input", async ({
+      request,
+    }) => {
       const user = await createTestUser(request);
 
       const response = await request.put(`${API_URL}/users/me`, {
-        data: { displayName: 'X' }, // Too short (min 2)
+        data: { displayName: "X" }, // Too short (min 2)
         headers: authHeaders(user.accessToken),
       });
 
       expect(response.status()).toBe(400);
       const body = await response.json();
-      expect(body.code).toBe('VALIDATION_ERROR');
+      expect(body.code).toBe("VALIDATION_ERROR");
       expect(body.details).toBeDefined();
       expect(body.details.length).toBeGreaterThan(0);
       expect(body.details[0].field).toBeDefined();
       expect(body.details[0].message).toBeDefined();
     });
 
-    test('GET /users/me returns social links and privacy settings', async ({ request }) => {
+    test("GET /users/me returns social links and privacy settings", async ({
+      request,
+    }) => {
       const user = await createTestUser(request);
 
       // Update social links first
       await request.put(`${API_URL}/users/me`, {
-        data: { socialLinks: { youtube: 'UCtest456' } },
+        data: { socialLinks: { youtube: "UCtest456" } },
         headers: authHeaders(user.accessToken),
       });
 
@@ -418,13 +432,13 @@ test.describe('User Service API', () => {
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
-      expect(body.socialLinks.youtube).toBe('UCtest456');
+      expect(body.socialLinks.youtube).toBe("UCtest456");
       expect(body.privacySettings).toBeDefined();
     });
   });
 
-  test.describe('Get User Public Profile', () => {
-    test('returns public profile fields', async ({ request }) => {
+  test.describe("Get User Public Profile", () => {
+    test("returns public profile fields", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.get(`${API_URL}/users/${user.id}`);
@@ -439,12 +453,14 @@ test.describe('User Service API', () => {
       expect(body.privacySettings).toBeUndefined();
     });
 
-    test('hides social links from anonymous when visibility is REGISTERED', async ({ request }) => {
+    test("hides social links from anonymous when visibility is REGISTERED", async ({
+      request,
+    }) => {
       const user = await createTestUser(request);
 
       // Set social links with REGISTERED visibility (default)
       await request.put(`${API_URL}/users/me`, {
-        data: { socialLinks: { youtube: 'UCprivate' } },
+        data: { socialLinks: { youtube: "UCprivate" } },
         headers: authHeaders(user.accessToken),
       });
 
@@ -454,13 +470,15 @@ test.describe('User Service API', () => {
       expect(body.socialLinks).toBeUndefined();
     });
 
-    test('shows social links to registered user when visibility is REGISTERED', async ({ request }) => {
+    test("shows social links to registered user when visibility is REGISTERED", async ({
+      request,
+    }) => {
       const user1 = await createTestUser(request);
       const user2 = await createTestUser(request);
 
       // User1 sets social links (default REGISTERED visibility)
       await request.put(`${API_URL}/users/me`, {
-        data: { socialLinks: { youtube: 'UCvisible' } },
+        data: { socialLinks: { youtube: "UCvisible" } },
         headers: authHeaders(user1.accessToken),
       });
 
@@ -469,10 +487,10 @@ test.describe('User Service API', () => {
         headers: authHeaders(user2.accessToken),
       });
       const body = await response.json();
-      expect(body.socialLinks.youtube).toBe('UCvisible');
+      expect(body.socialLinks.youtube).toBe("UCvisible");
     });
 
-    test('shows trustTier to authenticated viewer', async ({ request }) => {
+    test("shows trustTier to authenticated viewer", async ({ request }) => {
       const user1 = await createTestUser(request);
       const user2 = await createTestUser(request);
 
@@ -482,47 +500,57 @@ test.describe('User Service API', () => {
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
-      expect(body.trustTier).toBe('NEW');
+      expect(body.trustTier).toBe("NEW");
     });
 
-    test('returns 404 for non-existent user', async ({ request }) => {
-      const response = await request.get(`${API_URL}/users/00000000-0000-0000-0000-000000000099`);
+    test("returns 404 for non-existent user", async ({ request }) => {
+      const response = await request.get(
+        `${API_URL}/users/00000000-0000-0000-0000-000000000099`,
+      );
       expect(response.status()).toBe(404);
     });
   });
 
-  test.describe('Trust Tier Management', () => {
-    test('requires authentication to update trust tier', async ({ request }) => {
-      const response = await request.put(`${API_URL}/users/00000000-0000-0000-0000-000000000000/trust-tier`, {
-        data: {
-          trustTier: 'TRUSTED',
+  test.describe("Trust Tier Management", () => {
+    test("requires authentication to update trust tier", async ({
+      request,
+    }) => {
+      const response = await request.put(
+        `${API_URL}/users/00000000-0000-0000-0000-000000000000/trust-tier`,
+        {
+          data: {
+            trustTier: "TRUSTED",
+          },
         },
-      });
+      );
 
       expect([401, 403]).toContain(response.status());
     });
 
-    test('requires admin role to update trust tier', async ({ request }) => {
+    test("requires admin role to update trust tier", async ({ request }) => {
       const user = await createTestUser(request);
       const targetUser = await createTestUser(request);
 
-      const response = await request.put(`${API_URL}/users/${targetUser.id}/trust-tier`, {
-        data: {
-          trustTier: 'TRUSTED',
-          reason: 'Test promotion',
+      const response = await request.put(
+        `${API_URL}/users/${targetUser.id}/trust-tier`,
+        {
+          data: {
+            trustTier: "TRUSTED",
+            reason: "Test promotion",
+          },
+          headers: authHeaders(user.accessToken),
         },
-        headers: authHeaders(user.accessToken),
-      });
+      );
 
       // Regular users should get 403 Forbidden
       expect(response.status()).toBe(403);
     });
   });
 
-  test.describe('Password Reset', () => {
+  test.describe("Password Reset", () => {
     // TODO: Password reset endpoint not yet implemented
     // See: https://github.com/kelleyglenn/AcctAtlas-user-service/issues/25
-    test.skip('accepts password reset request', async ({ request }) => {
+    test.skip("accepts password reset request", async ({ request }) => {
       const user = await createTestUser(request);
 
       const response = await request.post(`${API_URL}/auth/password/reset`, {
@@ -537,7 +565,9 @@ test.describe('User Service API', () => {
 
     // TODO: Password reset endpoint not yet implemented
     // See: https://github.com/kelleyglenn/AcctAtlas-user-service/issues/25
-    test.skip('accepts reset request for non-existent email', async ({ request }) => {
+    test.skip("accepts reset request for non-existent email", async ({
+      request,
+    }) => {
       const response = await request.post(`${API_URL}/auth/password/reset`, {
         data: {
           email: `nonexistent-${Date.now()}@example.com`,
@@ -550,10 +580,10 @@ test.describe('User Service API', () => {
 
     // TODO: Password reset endpoint not yet implemented
     // See: https://github.com/kelleyglenn/AcctAtlas-user-service/issues/25
-    test.skip('validates email format', async ({ request }) => {
+    test.skip("validates email format", async ({ request }) => {
       const response = await request.post(`${API_URL}/auth/password/reset`, {
         data: {
-          email: 'not-an-email',
+          email: "not-an-email",
         },
       });
 
@@ -562,13 +592,16 @@ test.describe('User Service API', () => {
 
     // TODO: Password reset confirm endpoint not yet implemented
     // See: https://github.com/kelleyglenn/AcctAtlas-user-service/issues/25
-    test.skip('rejects invalid reset token', async ({ request }) => {
-      const response = await request.post(`${API_URL}/auth/password/reset/confirm`, {
-        data: {
-          token: 'invalid-reset-token',
-          newPassword: 'NewSecurePass123!',
+    test.skip("rejects invalid reset token", async ({ request }) => {
+      const response = await request.post(
+        `${API_URL}/auth/password/reset/confirm`,
+        {
+          data: {
+            token: "invalid-reset-token",
+            newPassword: "NewSecurePass123!",
+          },
         },
-      });
+      );
 
       expect(response.status()).toBe(400);
     });

--- a/api/tests/video-submission.spec.ts
+++ b/api/tests/video-submission.spec.ts
@@ -1,46 +1,48 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 import {
   API_URL,
   createTestUser,
   createTestLocation,
   authHeaders,
   deleteTestLocations,
-} from '../fixtures/api-helpers.js';
+} from "../fixtures/api-helpers.js";
 
-test.describe('Video Submission Flow', () => {
+test.describe("Video Submission Flow", () => {
   const createdLocationIds: string[] = [];
 
   test.afterAll(() => {
     deleteTestLocations(createdLocationIds);
   });
 
-  test.describe('Preview Endpoint', () => {
-    test('preview endpoint returns YouTube metadata', async ({ request }) => {
+  test.describe("Preview Endpoint", () => {
+    test("preview endpoint returns YouTube metadata", async ({ request }) => {
       const response = await request.get(`${API_URL}/videos/preview`, {
-        params: { youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+        params: { youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
       });
 
       expect(response.ok()).toBeTruthy();
       const body = await response.json();
 
-      expect(body.youtubeId).toBe('dQw4w9WgXcQ');
+      expect(body.youtubeId).toBe("dQw4w9WgXcQ");
       expect(body.title).toBeTruthy();
       expect(body.thumbnailUrl).toBeTruthy();
       expect(body.channelName).toBeTruthy();
       expect(body.alreadyExists).toBeDefined();
     });
 
-    test('preview endpoint requires valid YouTube URL', async ({ request }) => {
+    test("preview endpoint requires valid YouTube URL", async ({ request }) => {
       const response = await request.get(`${API_URL}/videos/preview`, {
-        params: { youtubeUrl: 'not-a-url' },
+        params: { youtubeUrl: "not-a-url" },
       });
 
       expect(response.status()).toBe(400);
     });
 
-    test('preview endpoint does not require authentication', async ({ request }) => {
+    test("preview endpoint does not require authentication", async ({
+      request,
+    }) => {
       const response = await request.get(`${API_URL}/videos/preview`, {
-        params: { youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+        params: { youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
       });
 
       expect(response.ok()).toBeTruthy();
@@ -48,8 +50,8 @@ test.describe('Video Submission Flow', () => {
     });
   });
 
-  test.describe('Full Submission Flow', () => {
-    test('full submission flow: preview, create location, create video, verify detail', async ({
+  test.describe("Full Submission Flow", () => {
+    test("full submission flow: preview, create location, create video, verify detail", async ({
       request,
     }) => {
       // 1. Create test user
@@ -57,18 +59,18 @@ test.describe('Video Submission Flow', () => {
 
       // 2. Preview a video
       const previewResponse = await request.get(`${API_URL}/videos/preview`, {
-        params: { youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+        params: { youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
       });
       expect(previewResponse.ok()).toBeTruthy();
       const preview = await previewResponse.json();
-      expect(preview.youtubeId).toBe('dQw4w9WgXcQ');
+      expect(preview.youtubeId).toBe("dQw4w9WgXcQ");
       expect(preview.title).toBeTruthy();
 
       // 3. If video already exists (from previous run), verify detail directly
       if (preview.alreadyExists) {
         const detailResponse = await request.get(
           `${API_URL}/videos/${preview.existingVideoId}`,
-          { headers: authHeaders(user.accessToken) }
+          { headers: authHeaders(user.accessToken) },
         );
         if (!detailResponse.ok()) {
           // Video exists but current user may not have permission (e.g., PENDING status, different owner)
@@ -76,7 +78,7 @@ test.describe('Video Submission Flow', () => {
           return;
         }
         const detail = await detailResponse.json();
-        expect(detail.youtubeId).toBe('dQw4w9WgXcQ');
+        expect(detail.youtubeId).toBe("dQw4w9WgXcQ");
         return;
       }
 
@@ -87,9 +89,9 @@ test.describe('Video Submission Flow', () => {
       // 5. Submit the video with that location
       const createResponse = await request.post(`${API_URL}/videos`, {
         data: {
-          youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-          amendments: ['FIRST'],
-          participants: ['POLICE'],
+          youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          amendments: ["FIRST"],
+          participants: ["POLICE"],
           locationId: location.id,
         },
         headers: authHeaders(user.accessToken),
@@ -99,24 +101,27 @@ test.describe('Video Submission Flow', () => {
       expect(created.id).toBeTruthy();
 
       // 6. Verify detail returns with locations
-      const detailResponse = await request.get(`${API_URL}/videos/${created.id}`, {
-        headers: authHeaders(user.accessToken),
-      });
+      const detailResponse = await request.get(
+        `${API_URL}/videos/${created.id}`,
+        {
+          headers: authHeaders(user.accessToken),
+        },
+      );
       expect(detailResponse.ok()).toBeTruthy();
       const detail = await detailResponse.json();
-      expect(detail.youtubeId).toBe('dQw4w9WgXcQ');
-      expect(detail.amendments).toContain('FIRST');
+      expect(detail.youtubeId).toBe("dQw4w9WgXcQ");
+      expect(detail.amendments).toContain("FIRST");
       expect(detail.locations).toBeDefined();
       expect(detail.locations.length).toBeGreaterThan(0);
     });
 
-    test('submission without auth returns 401/403', async ({ request }) => {
+    test("submission without auth returns 401/403", async ({ request }) => {
       const response = await request.post(`${API_URL}/videos`, {
         data: {
-          youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-          amendments: ['FIRST'],
-          participants: ['POLICE'],
-          locationId: '00000000-0000-0000-0000-000000000000',
+          youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          amendments: ["FIRST"],
+          participants: ["POLICE"],
+          locationId: "00000000-0000-0000-0000-000000000000",
         },
       });
 

--- a/docs/plans/2026-02-13-map-e2e-tests-design.md
+++ b/docs/plans/2026-02-13-map-e2e-tests-design.md
@@ -25,69 +25,69 @@ Tests use the existing dev seed data (10 videos across US locations). No API mut
 ```typescript
 export const SEED_VIDEOS = {
   SF_FIRST_AMENDMENT: {
-    id: '10000000-0000-0000-0000-000000000001',
-    title: 'Northern California Government Building Audit',
-    amendments: ['FIRST'],
-    participants: ['POLICE', 'GOVERNMENT'],
-    city: 'San Francisco',
+    id: "10000000-0000-0000-0000-000000000001",
+    title: "Northern California Government Building Audit",
+    amendments: ["FIRST"],
+    participants: ["POLICE", "GOVERNMENT"],
+    city: "San Francisco",
   },
   OAKLAND_MULTI_AMENDMENT: {
-    id: '10000000-0000-0000-0000-000000000002',
-    title: 'East Lansing Police Department Audit Analysis',
-    amendments: ['FIRST', 'FOURTH'],
-    participants: ['POLICE'],
-    city: 'Oakland',
+    id: "10000000-0000-0000-0000-000000000002",
+    title: "East Lansing Police Department Audit Analysis",
+    amendments: ["FIRST", "FOURTH"],
+    participants: ["POLICE"],
+    city: "Oakland",
   },
   SAN_ANTONIO_BUSINESS: {
-    id: '10000000-0000-0000-0000-000000000006',
-    title: 'San Antonio Strip Mall Encounter',
-    amendments: ['FIRST'],
-    participants: ['POLICE', 'BUSINESS'],
-    city: 'San Antonio',
+    id: "10000000-0000-0000-0000-000000000006",
+    title: "San Antonio Strip Mall Encounter",
+    amendments: ["FIRST"],
+    participants: ["POLICE", "BUSINESS"],
+    city: "San Antonio",
   },
 } as const;
 
-export const NON_EXISTENT_VIDEO_ID = '00000000-0000-0000-0000-000000000000';
+export const NON_EXISTENT_VIDEO_ID = "00000000-0000-0000-0000-000000000000";
 ```
 
 ## Test Cases
 
 ### Map Browse Tests (`e2e/tests/map/map-browse.spec.ts`)
 
-| Test | Description |
-|------|-------------|
-| map page loads with video markers | Navigate to /map, verify markers with `data-video-id` appear |
-| clicking marker shows video info popup | Click marker, verify popup with title and "View Video" button |
-| clicking "View Video" navigates to detail page | From popup, click button, verify URL `/videos/[id]` |
-| filter by amendment updates video list | Toggle "1st Amendment" chip, verify list filters |
-| filter by participant updates video list | Toggle "Police" chip, verify list filters |
-| location search flies to location and shows toast | Search city, verify toast "Moved to..." |
-| clicking video in list shows marker popup | Click VideoListItem, verify popup appears |
+| Test                                              | Description                                                   |
+| ------------------------------------------------- | ------------------------------------------------------------- |
+| map page loads with video markers                 | Navigate to /map, verify markers with `data-video-id` appear  |
+| clicking marker shows video info popup            | Click marker, verify popup with title and "View Video" button |
+| clicking "View Video" navigates to detail page    | From popup, click button, verify URL `/videos/[id]`           |
+| filter by amendment updates video list            | Toggle "1st Amendment" chip, verify list filters              |
+| filter by participant updates video list          | Toggle "Police" chip, verify list filters                     |
+| location search flies to location and shows toast | Search city, verify toast "Moved to..."                       |
+| clicking video in list shows marker popup         | Click VideoListItem, verify popup appears                     |
 
 ### Video Detail Tests (`e2e/tests/videos/video-detail.spec.ts`)
 
-| Test | Description |
-|------|-------------|
-| video detail page shows video information | Navigate to `/videos/[id]`, verify title, YouTube embed, amendments |
-| video detail page shows location information | Verify location name, city, state |
-| back button returns to previous page | From /map to /videos/[id], click back, verify /map |
-| "Watch on YouTube" link has correct URL | Verify href contains YouTube video ID |
-| "Back to Map" button navigates to map | Click button, verify URL /map |
-| shows error for non-existent video | Navigate to invalid ID, verify "Video not found" |
+| Test                                         | Description                                                         |
+| -------------------------------------------- | ------------------------------------------------------------------- |
+| video detail page shows video information    | Navigate to `/videos/[id]`, verify title, YouTube embed, amendments |
+| video detail page shows location information | Verify location name, city, state                                   |
+| back button returns to previous page         | From /map to /videos/[id], click back, verify /map                  |
+| "Watch on YouTube" link has correct URL      | Verify href contains YouTube video ID                               |
+| "Back to Map" button navigates to map        | Click button, verify URL /map                                       |
+| shows error for non-existent video           | Navigate to invalid ID, verify "Video not found"                    |
 
 ## Locator Strategy
 
 Following existing patterns from `login.spec.ts`:
 
-| Element | Locator |
-|---------|---------|
-| Video markers | `page.locator('[data-video-id]')` |
-| Filter chips | `page.getByRole('button', { name: '1st Amendment' })` |
-| Video list items | `page.getByRole('listitem')` or title text |
-| Location search | `page.getByRole('searchbox')` or placeholder |
-| Toast messages | `page.getByText(/Moved to/i)` |
-| Popup buttons | `page.getByRole('button', { name: /View Video/i })` |
-| YouTube embed | `page.locator('iframe[src*="youtube"]')` |
+| Element          | Locator                                               |
+| ---------------- | ----------------------------------------------------- |
+| Video markers    | `page.locator('[data-video-id]')`                     |
+| Filter chips     | `page.getByRole('button', { name: '1st Amendment' })` |
+| Video list items | `page.getByRole('listitem')` or title text            |
+| Location search  | `page.getByRole('searchbox')` or placeholder          |
+| Toast messages   | `page.getByText(/Moved to/i)`                         |
+| Popup buttons    | `page.getByRole('button', { name: /View Video/i })`   |
+| YouTube embed    | `page.locator('iframe[src*="youtube"]')`              |
 
 ## Browser Considerations
 

--- a/docs/plans/2026-02-13-map-e2e-tests.md
+++ b/docs/plans/2026-02-13-map-e2e-tests.md
@@ -13,6 +13,7 @@
 ## Task 1: Create Seed Data Fixture
 
 **Files:**
+
 - Create: `e2e/fixtures/seed-data.ts`
 
 **Step 1: Create the seed data constants file**
@@ -27,45 +28,45 @@
  */
 export const SEED_VIDEOS = {
   SF_FIRST_AMENDMENT: {
-    id: '10000000-0000-0000-0000-000000000001',
-    youtubeId: 'RngL8_3k0C0',
-    title: 'Northern California Government Building Audit',
-    amendments: ['FIRST'],
-    participants: ['POLICE', 'GOVERNMENT'],
-    city: 'San Francisco',
-    state: 'CA',
+    id: "10000000-0000-0000-0000-000000000001",
+    youtubeId: "RngL8_3k0C0",
+    title: "Northern California Government Building Audit",
+    amendments: ["FIRST"],
+    participants: ["POLICE", "GOVERNMENT"],
+    city: "San Francisco",
+    state: "CA",
   },
   OAKLAND_MULTI_AMENDMENT: {
-    id: '10000000-0000-0000-0000-000000000002',
-    youtubeId: 'nQRpazbSRf4',
-    title: 'East Lansing Police Department Audit Analysis',
-    amendments: ['FIRST', 'FOURTH'],
-    participants: ['POLICE'],
-    city: 'Oakland',
-    state: 'CA',
+    id: "10000000-0000-0000-0000-000000000002",
+    youtubeId: "nQRpazbSRf4",
+    title: "East Lansing Police Department Audit Analysis",
+    amendments: ["FIRST", "FOURTH"],
+    participants: ["POLICE"],
+    city: "Oakland",
+    state: "CA",
   },
   SAN_ANTONIO_BUSINESS: {
-    id: '10000000-0000-0000-0000-000000000006',
-    youtubeId: '-kNacBPsNxo',
-    title: 'San Antonio Strip Mall Encounter',
-    amendments: ['FIRST'],
-    participants: ['POLICE', 'BUSINESS'],
-    city: 'San Antonio',
-    state: 'TX',
+    id: "10000000-0000-0000-0000-000000000006",
+    youtubeId: "-kNacBPsNxo",
+    title: "San Antonio Strip Mall Encounter",
+    amendments: ["FIRST"],
+    participants: ["POLICE", "BUSINESS"],
+    city: "San Antonio",
+    state: "TX",
   },
   SILVERTHORNE_GOVERNMENT: {
-    id: '10000000-0000-0000-0000-000000000008',
-    youtubeId: 'hkhrXPur4ws',
-    title: 'Silverthorne Post Office Audit',
-    amendments: ['FIRST'],
-    participants: ['GOVERNMENT'],
-    city: 'Silverthorne',
-    state: 'CO',
+    id: "10000000-0000-0000-0000-000000000008",
+    youtubeId: "hkhrXPur4ws",
+    title: "Silverthorne Post Office Audit",
+    amendments: ["FIRST"],
+    participants: ["GOVERNMENT"],
+    city: "Silverthorne",
+    state: "CO",
   },
 } as const;
 
 /** Non-existent ID for 404 tests */
-export const NON_EXISTENT_VIDEO_ID = '00000000-0000-0000-0000-000000000000';
+export const NON_EXISTENT_VIDEO_ID = "00000000-0000-0000-0000-000000000000";
 
 /** Total count of seed videos */
 export const SEED_VIDEO_COUNT = 10;
@@ -88,27 +89,28 @@ git commit -m "feat(e2e): add seed data fixture for map tests"
 ## Task 2: Create Map Browse Test File with First Test
 
 **Files:**
+
 - Create: `e2e/tests/map/map-browse.spec.ts`
 
 **Step 1: Create test file with map loads test**
 
 ```typescript
 // e2e/tests/map/map-browse.spec.ts
-import { test, expect } from '@playwright/test';
-import { SEED_VIDEOS } from '../../fixtures/seed-data';
+import { test, expect } from "@playwright/test";
+import { SEED_VIDEOS } from "../../fixtures/seed-data";
 
-test.describe('Map Browse', () => {
-  test('map page loads with video markers', async ({ page, browserName }) => {
+test.describe("Map Browse", () => {
+  test("map page loads with video markers", async ({ page, browserName }) => {
     // Act: navigate to map page
-    await page.goto('/map');
+    await page.goto("/map");
 
     // Wait for map to render (WebGL can be slow)
-    if (browserName === 'webkit') {
+    if (browserName === "webkit") {
       await page.waitForTimeout(500);
     }
 
     // Assert: at least one video marker is visible
-    const markers = page.locator('[data-video-id]');
+    const markers = page.locator("[data-video-id]");
     await expect(markers.first()).toBeVisible({ timeout: 10000 });
 
     // Assert: multiple markers present (seed data has 10 videos)
@@ -135,6 +137,7 @@ git commit -m "feat(e2e): add map page loads test"
 ## Task 3: Add Marker Click and Popup Tests
 
 **Files:**
+
 - Modify: `e2e/tests/map/map-browse.spec.ts`
 
 **Step 1: Add marker click test**
@@ -142,38 +145,44 @@ git commit -m "feat(e2e): add map page loads test"
 Add after the first test:
 
 ```typescript
-  test('clicking marker shows video info popup', async ({ page, browserName }) => {
-    // Arrange: go to map
-    await page.goto('/map');
-    if (browserName === 'webkit') {
-      await page.waitForTimeout(500);
-    }
+test("clicking marker shows video info popup", async ({
+  page,
+  browserName,
+}) => {
+  // Arrange: go to map
+  await page.goto("/map");
+  if (browserName === "webkit") {
+    await page.waitForTimeout(500);
+  }
 
-    // Act: click the first marker
-    const marker = page.locator('[data-video-id]').first();
-    await expect(marker).toBeVisible({ timeout: 10000 });
-    await marker.click();
+  // Act: click the first marker
+  const marker = page.locator("[data-video-id]").first();
+  await expect(marker).toBeVisible({ timeout: 10000 });
+  await marker.click();
 
-    // Assert: popup appears with View Video button
-    await expect(page.getByRole('button', { name: /View Video/i })).toBeVisible();
-  });
+  // Assert: popup appears with View Video button
+  await expect(page.getByRole("button", { name: /View Video/i })).toBeVisible();
+});
 
-  test('clicking "View Video" navigates to detail page', async ({ page, browserName }) => {
-    // Arrange: go to map and click marker
-    await page.goto('/map');
-    if (browserName === 'webkit') {
-      await page.waitForTimeout(500);
-    }
-    const marker = page.locator('[data-video-id]').first();
-    await expect(marker).toBeVisible({ timeout: 10000 });
-    await marker.click();
+test('clicking "View Video" navigates to detail page', async ({
+  page,
+  browserName,
+}) => {
+  // Arrange: go to map and click marker
+  await page.goto("/map");
+  if (browserName === "webkit") {
+    await page.waitForTimeout(500);
+  }
+  const marker = page.locator("[data-video-id]").first();
+  await expect(marker).toBeVisible({ timeout: 10000 });
+  await marker.click();
 
-    // Act: click View Video button
-    await page.getByRole('button', { name: /View Video/i }).click();
+  // Act: click View Video button
+  await page.getByRole("button", { name: /View Video/i }).click();
 
-    // Assert: navigated to video detail page
-    await expect(page).toHaveURL(/\/videos\/[a-f0-9-]+/);
-  });
+  // Assert: navigated to video detail page
+  await expect(page).toHaveURL(/\/videos\/[a-f0-9-]+/);
+});
 ```
 
 **Step 2: Run tests**
@@ -193,51 +202,62 @@ git commit -m "feat(e2e): add marker click and popup tests"
 ## Task 4: Add Filter Tests
 
 **Files:**
+
 - Modify: `e2e/tests/map/map-browse.spec.ts`
 
 **Step 1: Add amendment filter test**
 
 ```typescript
-  test('filter by amendment updates video list', async ({ page, browserName }) => {
-    // Arrange: go to map
-    await page.goto('/map');
-    if (browserName === 'webkit') {
-      await page.waitForTimeout(500);
-    }
-    await expect(page.locator('[data-video-id]').first()).toBeVisible({ timeout: 10000 });
-
-    // Get initial video count in list
-    const videoList = page.locator('[data-testid="video-list-item"]');
-    const initialCount = await videoList.count();
-
-    // Act: click 4th Amendment filter (fewer videos have this)
-    await page.getByRole('button', { name: /4th/i }).click();
-
-    // Assert: list is filtered (count changes or specific video visible)
-    // Note: All seed videos have FIRST, only 3 have FOURTH
-    await page.waitForTimeout(300); // Allow filter to apply
-    const filteredCount = await videoList.count();
-    expect(filteredCount).toBeLessThanOrEqual(initialCount);
+test("filter by amendment updates video list", async ({
+  page,
+  browserName,
+}) => {
+  // Arrange: go to map
+  await page.goto("/map");
+  if (browserName === "webkit") {
+    await page.waitForTimeout(500);
+  }
+  await expect(page.locator("[data-video-id]").first()).toBeVisible({
+    timeout: 10000,
   });
 
-  test('filter by participant updates video list', async ({ page, browserName }) => {
-    // Arrange: go to map
-    await page.goto('/map');
-    if (browserName === 'webkit') {
-      await page.waitForTimeout(500);
-    }
-    await expect(page.locator('[data-video-id]').first()).toBeVisible({ timeout: 10000 });
+  // Get initial video count in list
+  const videoList = page.locator('[data-testid="video-list-item"]');
+  const initialCount = await videoList.count();
 
-    // Act: click Government filter
-    await page.getByRole('button', { name: /Government/i }).click();
+  // Act: click 4th Amendment filter (fewer videos have this)
+  await page.getByRole("button", { name: /4th/i }).click();
 
-    // Assert: Government-tagged videos visible
-    await page.waitForTimeout(300);
-    // The filter should show only videos with GOVERNMENT participant
-    const videoList = page.locator('[data-testid="video-list-item"]');
-    const count = await videoList.count();
-    expect(count).toBeGreaterThan(0);
+  // Assert: list is filtered (count changes or specific video visible)
+  // Note: All seed videos have FIRST, only 3 have FOURTH
+  await page.waitForTimeout(300); // Allow filter to apply
+  const filteredCount = await videoList.count();
+  expect(filteredCount).toBeLessThanOrEqual(initialCount);
+});
+
+test("filter by participant updates video list", async ({
+  page,
+  browserName,
+}) => {
+  // Arrange: go to map
+  await page.goto("/map");
+  if (browserName === "webkit") {
+    await page.waitForTimeout(500);
+  }
+  await expect(page.locator("[data-video-id]").first()).toBeVisible({
+    timeout: 10000,
   });
+
+  // Act: click Government filter
+  await page.getByRole("button", { name: /Government/i }).click();
+
+  // Assert: Government-tagged videos visible
+  await page.waitForTimeout(300);
+  // The filter should show only videos with GOVERNMENT participant
+  const videoList = page.locator('[data-testid="video-list-item"]');
+  const count = await videoList.count();
+  expect(count).toBeGreaterThan(0);
+});
 ```
 
 **Step 2: Run tests**
@@ -257,47 +277,58 @@ git commit -m "feat(e2e): add filter tests for amendments and participants"
 ## Task 5: Add Location Search and Video List Tests
 
 **Files:**
+
 - Modify: `e2e/tests/map/map-browse.spec.ts`
 
 **Step 1: Add location search test**
 
 ```typescript
-  test('location search flies to location and shows toast', async ({ page, browserName }) => {
-    // Arrange: go to map
-    await page.goto('/map');
-    if (browserName === 'webkit') {
-      await page.waitForTimeout(500);
-    }
+test("location search flies to location and shows toast", async ({
+  page,
+  browserName,
+}) => {
+  // Arrange: go to map
+  await page.goto("/map");
+  if (browserName === "webkit") {
+    await page.waitForTimeout(500);
+  }
 
-    // Act: type in search box and select result
-    const searchBox = page.getByRole('combobox').or(page.locator('input[placeholder*="Search"]'));
-    await searchBox.fill('Denver');
+  // Act: type in search box and select result
+  const searchBox = page
+    .getByRole("combobox")
+    .or(page.locator('input[placeholder*="Search"]'));
+  await searchBox.fill("Denver");
 
-    // Wait for autocomplete and click first result
-    const suggestion = page.getByRole('option').first();
-    await expect(suggestion).toBeVisible({ timeout: 5000 });
-    await suggestion.click();
+  // Wait for autocomplete and click first result
+  const suggestion = page.getByRole("option").first();
+  await expect(suggestion).toBeVisible({ timeout: 5000 });
+  await suggestion.click();
 
-    // Assert: toast appears
-    await expect(page.getByText(/Moved to/i)).toBeVisible({ timeout: 5000 });
+  // Assert: toast appears
+  await expect(page.getByText(/Moved to/i)).toBeVisible({ timeout: 5000 });
+});
+
+test("clicking video in list shows marker popup", async ({
+  page,
+  browserName,
+}) => {
+  // Arrange: go to map
+  await page.goto("/map");
+  if (browserName === "webkit") {
+    await page.waitForTimeout(500);
+  }
+  await expect(page.locator("[data-video-id]").first()).toBeVisible({
+    timeout: 10000,
   });
 
-  test('clicking video in list shows marker popup', async ({ page, browserName }) => {
-    // Arrange: go to map
-    await page.goto('/map');
-    if (browserName === 'webkit') {
-      await page.waitForTimeout(500);
-    }
-    await expect(page.locator('[data-video-id]').first()).toBeVisible({ timeout: 10000 });
+  // Act: click a video in the side panel list
+  const listItem = page.locator('[data-testid="video-list-item"]').first();
+  await expect(listItem).toBeVisible();
+  await listItem.click();
 
-    // Act: click a video in the side panel list
-    const listItem = page.locator('[data-testid="video-list-item"]').first();
-    await expect(listItem).toBeVisible();
-    await listItem.click();
-
-    // Assert: popup appears with View Video button
-    await expect(page.getByRole('button', { name: /View Video/i })).toBeVisible();
-  });
+  // Assert: popup appears with View Video button
+  await expect(page.getByRole("button", { name: /View Video/i })).toBeVisible();
+});
 ```
 
 **Step 2: Run tests**
@@ -317,17 +348,18 @@ git commit -m "feat(e2e): add location search and video list interaction tests"
 ## Task 6: Create Video Detail Test File
 
 **Files:**
+
 - Create: `e2e/tests/videos/video-detail.spec.ts`
 
 **Step 1: Create test file with basic tests**
 
 ```typescript
 // e2e/tests/videos/video-detail.spec.ts
-import { test, expect } from '@playwright/test';
-import { SEED_VIDEOS, NON_EXISTENT_VIDEO_ID } from '../../fixtures/seed-data';
+import { test, expect } from "@playwright/test";
+import { SEED_VIDEOS, NON_EXISTENT_VIDEO_ID } from "../../fixtures/seed-data";
 
-test.describe('Video Detail', () => {
-  test('video detail page shows video information', async ({ page }) => {
+test.describe("Video Detail", () => {
+  test("video detail page shows video information", async ({ page }) => {
     // Arrange: navigate directly to a known video
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
@@ -336,14 +368,18 @@ test.describe('Video Detail', () => {
     await expect(page.getByText(video.title)).toBeVisible({ timeout: 10000 });
 
     // Assert: YouTube embed is present
-    const iframe = page.locator(`iframe[src*="youtube.com/embed/${video.youtubeId}"]`);
+    const iframe = page.locator(
+      `iframe[src*="youtube.com/embed/${video.youtubeId}"]`,
+    );
     await expect(iframe).toBeVisible();
 
     // Assert: amendment badge is visible
-    await expect(page.getByText(/1st/i).or(page.getByText(/FIRST/i))).toBeVisible();
+    await expect(
+      page.getByText(/1st/i).or(page.getByText(/FIRST/i)),
+    ).toBeVisible();
   });
 
-  test('video detail page shows location information', async ({ page }) => {
+  test("video detail page shows location information", async ({ page }) => {
     // Arrange: navigate to known video
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
@@ -353,25 +389,31 @@ test.describe('Video Detail', () => {
     await expect(page.getByText(video.state)).toBeVisible();
   });
 
-  test('back button returns to previous page', async ({ page, browserName }) => {
+  test("back button returns to previous page", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: start at map, navigate to video
-    await page.goto('/map');
-    if (browserName === 'webkit') {
+    await page.goto("/map");
+    if (browserName === "webkit") {
       await page.waitForTimeout(500);
     }
 
     // Click marker and go to video
-    const marker = page.locator('[data-video-id]').first();
+    const marker = page.locator("[data-video-id]").first();
     await expect(marker).toBeVisible({ timeout: 10000 });
     await marker.click();
-    await page.getByRole('button', { name: /View Video/i }).click();
+    await page.getByRole("button", { name: /View Video/i }).click();
     await expect(page).toHaveURL(/\/videos\//);
 
     // Act: click back button
-    await page.getByRole('button', { name: /back/i }).or(page.locator('[aria-label="Go back"]')).click();
+    await page
+      .getByRole("button", { name: /back/i })
+      .or(page.locator('[aria-label="Go back"]'))
+      .click();
 
     // Assert: back at map
-    await expect(page).toHaveURL('/map');
+    await expect(page).toHaveURL("/map");
   });
 });
 ```
@@ -393,46 +435,50 @@ git commit -m "feat(e2e): add video detail page tests"
 ## Task 7: Add Remaining Video Detail Tests
 
 **Files:**
+
 - Modify: `e2e/tests/videos/video-detail.spec.ts`
 
 **Step 1: Add YouTube link, Back to Map, and 404 tests**
 
 ```typescript
-  test('"Watch on YouTube" link has correct URL', async ({ page }) => {
-    // Arrange: navigate to known video
-    const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
-    await page.goto(`/videos/${video.id}`);
+test('"Watch on YouTube" link has correct URL', async ({ page }) => {
+  // Arrange: navigate to known video
+  const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
+  await page.goto(`/videos/${video.id}`);
 
-    // Assert: YouTube link has correct href
-    const youtubeLink = page.getByRole('link', { name: /Watch on YouTube/i });
-    await expect(youtubeLink).toBeVisible({ timeout: 10000 });
-    await expect(youtubeLink).toHaveAttribute('href', `https://www.youtube.com/watch?v=${video.youtubeId}`);
-    await expect(youtubeLink).toHaveAttribute('target', '_blank');
-  });
+  // Assert: YouTube link has correct href
+  const youtubeLink = page.getByRole("link", { name: /Watch on YouTube/i });
+  await expect(youtubeLink).toBeVisible({ timeout: 10000 });
+  await expect(youtubeLink).toHaveAttribute(
+    "href",
+    `https://www.youtube.com/watch?v=${video.youtubeId}`,
+  );
+  await expect(youtubeLink).toHaveAttribute("target", "_blank");
+});
 
-  test('"Back to Map" button navigates to map', async ({ page }) => {
-    // Arrange: navigate to known video
-    const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
-    await page.goto(`/videos/${video.id}`);
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: 10000 });
+test('"Back to Map" button navigates to map', async ({ page }) => {
+  // Arrange: navigate to known video
+  const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
+  await page.goto(`/videos/${video.id}`);
+  await expect(page.getByText(video.title)).toBeVisible({ timeout: 10000 });
 
-    // Act: click Back to Map
-    await page.getByRole('link', { name: /Back to Map/i }).click();
+  // Act: click Back to Map
+  await page.getByRole("link", { name: /Back to Map/i }).click();
 
-    // Assert: at map page
-    await expect(page).toHaveURL('/map');
-  });
+  // Assert: at map page
+  await expect(page).toHaveURL("/map");
+});
 
-  test('shows error for non-existent video', async ({ page }) => {
-    // Act: navigate to non-existent video
-    await page.goto(`/videos/${NON_EXISTENT_VIDEO_ID}`);
+test("shows error for non-existent video", async ({ page }) => {
+  // Act: navigate to non-existent video
+  await page.goto(`/videos/${NON_EXISTENT_VIDEO_ID}`);
 
-    // Assert: error message shown
-    await expect(page.getByText(/not found/i)).toBeVisible({ timeout: 10000 });
+  // Assert: error message shown
+  await expect(page.getByText(/not found/i)).toBeVisible({ timeout: 10000 });
 
-    // Assert: link back to map exists
-    await expect(page.getByRole('link', { name: /map/i })).toBeVisible();
-  });
+  // Assert: link back to map exists
+  await expect(page.getByRole("link", { name: /map/i })).toBeVisible();
+});
 ```
 
 **Step 2: Run all video detail tests**
@@ -473,11 +519,11 @@ Modify `README.md` E2E Tests section:
 ```markdown
 ### E2E Tests (22 tests)
 
-| Feature | Tests | Coverage |
-|---------|-------|----------|
-| Auth | 9 | Login flow across 3 browsers |
-| Map | 7 | Map browsing, markers, filters, search |
-| Video | 6 | Video detail page, navigation, 404 |
+| Feature | Tests | Coverage                               |
+| ------- | ----- | -------------------------------------- |
+| Auth    | 9     | Login flow across 3 browsers           |
+| Map     | 7     | Map browsing, markers, filters, search |
+| Video   | 6     | Video detail page, navigation, 404     |
 ```
 
 **Step 5: Final commit**

--- a/e2e/fixtures/mapbox-search-mock.ts
+++ b/e2e/fixtures/mapbox-search-mock.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Page } from "@playwright/test";
 
 interface MockLocation {
   name: string;
@@ -8,13 +8,13 @@ interface MockLocation {
 
 const MOCK_LOCATIONS: Record<string, MockLocation> = {
   denver: {
-    name: 'Denver',
-    placeFormatted: 'Colorado, United States',
+    name: "Denver",
+    placeFormatted: "Colorado, United States",
     coordinates: [-104.9903, 39.7392],
   },
-  'san antonio': {
-    name: 'San Antonio',
-    placeFormatted: 'Texas, United States',
+  "san antonio": {
+    name: "San Antonio",
+    placeFormatted: "Texas, United States",
     coordinates: [-98.4936, 29.4241],
   },
 };
@@ -24,7 +24,7 @@ function findMockLocation(query: string): MockLocation {
   return (
     MOCK_LOCATIONS[key] ?? {
       name: query,
-      placeFormatted: 'United States',
+      placeFormatted: "United States",
       coordinates: [-98.5795, 39.8283],
     }
   );
@@ -38,53 +38,53 @@ function findMockLocation(query: string): MockLocation {
  */
 export async function mockMapboxSearchAPI(page: Page): Promise<void> {
   // Intercept suggest requests
-  await page.route('**/search/searchbox/v1/suggest**', (route) => {
+  await page.route("**/search/searchbox/v1/suggest**", (route) => {
     const url = new URL(route.request().url());
-    const query = url.searchParams.get('q') ?? '';
+    const query = url.searchParams.get("q") ?? "";
     const location = findMockLocation(query);
-    const mapboxId = location.name.toLowerCase().replace(/\s+/g, '-');
+    const mapboxId = location.name.toLowerCase().replace(/\s+/g, "-");
 
     route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: "application/json",
       body: JSON.stringify({
         suggestions: [
           {
             name: location.name,
             mapbox_id: mapboxId,
-            feature_type: 'place',
+            feature_type: "place",
             place_formatted: location.placeFormatted,
-            address: '',
+            address: "",
             full_address: `${location.name}, ${location.placeFormatted}`,
-            language: 'en',
-            maki: 'marker',
+            language: "en",
+            maki: "marker",
             context: {},
           },
         ],
-        attribution: 'mocked',
+        attribution: "mocked",
       }),
     });
   });
 
   // Intercept retrieve requests
-  await page.route('**/search/searchbox/v1/retrieve/**', (route) => {
+  await page.route("**/search/searchbox/v1/retrieve/**", (route) => {
     const url = new URL(route.request().url());
     // mapbox_id is the last path segment (URL-encoded)
-    const pathParts = url.pathname.split('/');
+    const pathParts = url.pathname.split("/");
     const mapboxId = decodeURIComponent(pathParts[pathParts.length - 1]);
-    const key = mapboxId.replace(/-/g, ' ');
+    const key = mapboxId.replace(/-/g, " ");
     const location = findMockLocation(key);
 
     route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: "application/json",
       body: JSON.stringify({
-        type: 'FeatureCollection',
+        type: "FeatureCollection",
         features: [
           {
-            type: 'Feature',
+            type: "Feature",
             geometry: {
-              type: 'Point',
+              type: "Point",
               coordinates: location.coordinates,
             },
             properties: {
@@ -97,7 +97,7 @@ export async function mockMapboxSearchAPI(page: Page): Promise<void> {
             },
           },
         ],
-        attribution: 'mocked',
+        attribution: "mocked",
       }),
     });
   });

--- a/e2e/fixtures/seed-data.ts
+++ b/e2e/fixtures/seed-data.ts
@@ -7,51 +7,51 @@
  */
 export const SEED_VIDEOS = {
   SF_FIRST_AMENDMENT: {
-    id: '10000000-0000-0000-0000-000000000001',
-    youtubeId: 'RngL8_3k0C0',
-    title: 'Northern California Government Building Audit',
-    amendments: ['FIRST'],
-    participants: ['POLICE', 'GOVERNMENT'],
-    city: 'San Francisco',
-    state: 'CA',
+    id: "10000000-0000-0000-0000-000000000001",
+    youtubeId: "RngL8_3k0C0",
+    title: "Northern California Government Building Audit",
+    amendments: ["FIRST"],
+    participants: ["POLICE", "GOVERNMENT"],
+    city: "San Francisco",
+    state: "CA",
     lat: 37.7793,
     lng: -122.4193,
   },
   OAKLAND_MULTI_AMENDMENT: {
-    id: '10000000-0000-0000-0000-000000000002',
-    youtubeId: 'nQRpazbSRf4',
-    title: 'East Lansing Police Department Audit Analysis',
-    amendments: ['FIRST', 'FOURTH'],
-    participants: ['POLICE'],
-    city: 'Oakland',
-    state: 'CA',
+    id: "10000000-0000-0000-0000-000000000002",
+    youtubeId: "nQRpazbSRf4",
+    title: "East Lansing Police Department Audit Analysis",
+    amendments: ["FIRST", "FOURTH"],
+    participants: ["POLICE"],
+    city: "Oakland",
+    state: "CA",
   },
   SAN_ANTONIO_BUSINESS: {
-    id: '10000000-0000-0000-0000-000000000006',
-    youtubeId: '-kNacBPsNxo',
-    title: 'San Antonio Strip Mall Encounter',
-    amendments: ['FIRST'],
-    participants: ['POLICE', 'BUSINESS'],
-    city: 'San Antonio',
-    state: 'TX',
+    id: "10000000-0000-0000-0000-000000000006",
+    youtubeId: "-kNacBPsNxo",
+    title: "San Antonio Strip Mall Encounter",
+    amendments: ["FIRST"],
+    participants: ["POLICE", "BUSINESS"],
+    city: "San Antonio",
+    state: "TX",
   },
   SILVERTHORNE_GOVERNMENT: {
-    id: '10000000-0000-0000-0000-000000000008',
-    youtubeId: 'hkhrXPur4ws',
-    title: 'Silverthorne Post Office Audit',
-    amendments: ['FIRST'],
-    participants: ['GOVERNMENT'],
-    city: 'Silverthorne',
-    state: 'CO',
+    id: "10000000-0000-0000-0000-000000000008",
+    youtubeId: "hkhrXPur4ws",
+    title: "Silverthorne Post Office Audit",
+    amendments: ["FIRST"],
+    participants: ["GOVERNMENT"],
+    city: "Silverthorne",
+    state: "CO",
   },
   UTICA_SECURITY: {
-    id: '10000000-0000-0000-0000-000000000004',
-    youtubeId: 'AJi0LgnoIJA',
-    title: 'Utica Michigan Police Confrontation',
-    amendments: ['FIRST', 'FOURTH'],
-    participants: ['POLICE', 'SECURITY'],
-    city: 'Fremont',
-    state: 'CA',
+    id: "10000000-0000-0000-0000-000000000004",
+    youtubeId: "AJi0LgnoIJA",
+    title: "Utica Michigan Police Confrontation",
+    amendments: ["FIRST", "FOURTH"],
+    participants: ["POLICE", "SECURITY"],
+    city: "Fremont",
+    state: "CA",
   },
 } as const;
 
@@ -59,14 +59,14 @@ export const SEED_VIDEOS = {
 export const SEED_USERS = {
   /** "Trusted User" who submitted all 10 seed videos (8 approved, 2 rejected) */
   TRUSTED_SUBMITTER: {
-    id: '00000000-0000-0000-0000-000000000003',
-    displayName: 'Trusted User',
-    trustTier: 'TRUSTED',
+    id: "00000000-0000-0000-0000-000000000003",
+    displayName: "Trusted User",
+    trustTier: "TRUSTED",
   },
 } as const;
 
 /** Non-existent ID for 404 tests */
-export const NON_EXISTENT_VIDEO_ID = '00000000-0000-0000-0000-000000000000';
+export const NON_EXISTENT_VIDEO_ID = "00000000-0000-0000-0000-000000000000";
 
 /** Total count of seed videos */
 export const SEED_VIDEO_COUNT = 10;

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -1,6 +1,6 @@
-import { APIRequestContext, Page, expect } from '@playwright/test';
+import { APIRequestContext, Page, expect } from "@playwright/test";
 
-const API_URL = process.env.API_URL || 'http://localhost:8080/api/v1';
+const API_URL = process.env.API_URL || "http://localhost:8080/api/v1";
 
 export interface TestUser {
   email: string;
@@ -11,12 +11,12 @@ export interface TestUser {
 
 export async function createTestUser(
   request: APIRequestContext,
-  overrides: Partial<Omit<TestUser, 'response'>> = {}
+  overrides: Partial<Omit<TestUser, "response">> = {},
 ): Promise<TestUser> {
   const userData = {
     email: `test-${Date.now()}@example.com`,
-    password: 'TestPass123!',
-    displayName: 'Test User',
+    password: "TestPass123!",
+    displayName: "Test User",
     ...overrides,
   };
 
@@ -31,13 +31,13 @@ export async function loginViaUI(
   page: Page,
   email: string,
   password: string,
-  browserName: string
+  browserName: string,
 ): Promise<void> {
-  await page.goto('/login');
-  const emailField = page.getByLabel('Email');
-  const passwordField = page.getByLabel('Password');
+  await page.goto("/login");
+  const emailField = page.getByLabel("Email");
+  const passwordField = page.getByLabel("Password");
 
-  if (browserName === 'webkit') {
+  if (browserName === "webkit") {
     await emailField.click();
     await emailField.fill(email);
     await passwordField.click();
@@ -46,14 +46,17 @@ export async function loginViaUI(
     await emailField.fill(email);
     await passwordField.fill(password);
   }
-  await page.locator('form').getByRole('button', { name: /Sign In/i }).click();
-  await expect(page).toHaveURL('/');
+  await page
+    .locator("form")
+    .getByRole("button", { name: /Sign In/i })
+    .click();
+  await expect(page).toHaveURL("/");
 }
 
 export async function loginAs(
   request: APIRequestContext,
   email: string,
-  password: string
+  password: string,
 ): Promise<string> {
   const response = await request.post(`${API_URL}/auth/login`, {
     data: { email, password },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,28 +1,28 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 1,
   workers: process.env.CI ? 1 : 4, // Limit local workers to avoid overwhelming backend
   reporter: [
-    ['html', { outputFolder: 'playwright-report' }],
-    ['github'],
-    ['junit', { outputFile: 'results.xml' }],
+    ["html", { outputFolder: "playwright-report" }],
+    ["github"],
+    ["junit", { outputFile: "results.xml" }],
   ],
 
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
+    baseURL: process.env.BASE_URL || "http://localhost:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
   },
 
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
-    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
   ],
 
-  outputDir: 'test-results',
+  outputDir: "test-results",
 });

--- a/e2e/seeds/README.md
+++ b/e2e/seeds/README.md
@@ -4,8 +4,8 @@ SQL scripts for creating test data that cannot be created via the public API.
 
 ## Available Seeds
 
-| File | Purpose | Credentials |
-|------|---------|-------------|
+| File                 | Purpose                       | Credentials                                  |
+| -------------------- | ----------------------------- | -------------------------------------------- |
 | `moderator-user.sql` | Creates a MODERATOR tier user | `moderator@test.local` / `ModeratorPass123!` |
 
 ## Usage

--- a/e2e/tests/auth/login.spec.ts
+++ b/e2e/tests/auth/login.spec.ts
@@ -1,19 +1,23 @@
-import { test, expect } from '@playwright/test';
-import { createTestUser } from '../../fixtures/test-data';
-import { PAGE_LOAD_TIMEOUT } from '../../fixtures/test-constants';
+import { test, expect } from "@playwright/test";
+import { createTestUser } from "../../fixtures/test-data";
+import { PAGE_LOAD_TIMEOUT } from "../../fixtures/test-constants";
 
-test.describe('Login', () => {
-  test('user can log in with valid credentials', async ({ page, request, browserName }) => {
+test.describe("Login", () => {
+  test("user can log in with valid credentials", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create a user via API
     const user = await createTestUser(request);
     expect(user.response.ok()).toBeTruthy();
 
     // Act: log in through the UI
-    await page.goto('/login');
-    const emailField = page.getByLabel('Email');
-    const passwordField = page.getByLabel('Password');
+    await page.goto("/login");
+    const emailField = page.getByLabel("Email");
+    const passwordField = page.getByLabel("Password");
 
-    if (browserName === 'webkit') {
+    if (browserName === "webkit") {
       // WebKit needs explicit clicks before filling inputs
       await emailField.click();
       await emailField.fill(user.email);
@@ -23,41 +27,53 @@ test.describe('Login', () => {
       await emailField.fill(user.email);
       await passwordField.fill(user.password);
     }
-    await page.locator('form').getByRole('button', { name: /Sign In/i }).click();
+    await page
+      .locator("form")
+      .getByRole("button", { name: /Sign In/i })
+      .click();
 
     // Assert: redirected to profile/home
-    await expect(page).toHaveURL('/');
-    await expect(page.getByRole('navigation').getByText(user.displayName)).toBeVisible();
+    await expect(page).toHaveURL("/");
+    await expect(
+      page.getByRole("navigation").getByText(user.displayName),
+    ).toBeVisible();
   });
 
-  test('shows error for invalid credentials', async ({ page, browserName }) => {
+  test("shows error for invalid credentials", async ({ page, browserName }) => {
     // Act: attempt login with invalid credentials
-    await page.goto('/login');
-    const emailField = page.getByLabel('Email');
-    const passwordField = page.getByLabel('Password');
+    await page.goto("/login");
+    const emailField = page.getByLabel("Email");
+    const passwordField = page.getByLabel("Password");
 
-    if (browserName === 'webkit') {
+    if (browserName === "webkit") {
       // WebKit needs explicit clicks before filling inputs
       await emailField.click();
-      await emailField.fill('nobody@example.com');
+      await emailField.fill("nobody@example.com");
       await passwordField.click();
-      await passwordField.fill('WrongPassword');
+      await passwordField.fill("WrongPassword");
     } else {
-      await emailField.fill('nobody@example.com');
-      await passwordField.fill('WrongPassword');
+      await emailField.fill("nobody@example.com");
+      await passwordField.fill("WrongPassword");
     }
-    await page.locator('form').getByRole('button', { name: /Sign In/i }).click();
+    await page
+      .locator("form")
+      .getByRole("button", { name: /Sign In/i })
+      .click();
 
     // Assert: error message displayed (API response can be slow under parallel test load)
-    await expect(page.getByRole('alert').getByText(/Email or password is incorrect/i)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(
+      page.getByRole("alert").getByText(/Email or password is incorrect/i),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
   });
 
-  test('login page is accessible', async ({ page }) => {
-    await page.goto('/login');
+  test("login page is accessible", async ({ page }) => {
+    await page.goto("/login");
 
     // Verify key elements are present
-    await expect(page.getByLabel('Email')).toBeVisible();
-    await expect(page.getByLabel('Password')).toBeVisible();
-    await expect(page.locator('form').getByRole('button', { name: /Sign In/i })).toBeVisible();
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Password")).toBeVisible();
+    await expect(
+      page.locator("form").getByRole("button", { name: /Sign In/i }),
+    ).toBeVisible();
   });
 });

--- a/e2e/tests/home/hero-landing.spec.ts
+++ b/e2e/tests/home/hero-landing.spec.ts
@@ -1,140 +1,201 @@
-import { test, expect } from '@playwright/test';
-import { createTestUser, loginViaUI } from '../../fixtures/test-data';
-import { PAGE_LOAD_TIMEOUT } from '../../fixtures/test-constants';
+import { test, expect } from "@playwright/test";
+import { createTestUser, loginViaUI } from "../../fixtures/test-data";
+import { PAGE_LOAD_TIMEOUT } from "../../fixtures/test-constants";
 
-test.describe('Hero Landing Page', () => {
-  test.describe('Hero Section', () => {
-    test('displays headline and subheadline', async ({ page }) => {
-      await page.goto('/');
+test.describe("Hero Landing Page", () => {
+  test.describe("Hero Section", () => {
+    test("displays headline and subheadline", async ({ page }) => {
+      await page.goto("/");
 
       await expect(
-        page.getByRole('heading', { name: 'See Where Constitutional Rights Are Tested' })
+        page.getByRole("heading", {
+          name: "See Where Constitutional Rights Are Tested",
+        }),
       ).toBeVisible();
 
       await expect(
-        page.getByText('AccountabilityAtlas organizes citizen-recorded audit videos')
+        page.getByText(
+          "AccountabilityAtlas organizes citizen-recorded audit videos",
+        ),
       ).toBeVisible();
     });
 
-    test('displays CTA buttons for unauthenticated user', async ({ page }) => {
-      await page.goto('/');
+    test("displays CTA buttons for unauthenticated user", async ({ page }) => {
+      await page.goto("/");
 
-      await expect(page.getByRole('link', { name: 'Explore the Map' }).first()).toBeVisible();
-      await expect(page.getByRole('link', { name: 'Create Free Account' }).first()).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Explore the Map" }).first(),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Create Free Account" }).first(),
+      ).toBeVisible();
     });
 
-    test('displays auth-aware CTAs when logged in', async ({ page, request, browserName }) => {
+    test("displays auth-aware CTAs when logged in", async ({
+      page,
+      request,
+      browserName,
+    }) => {
       // Arrange: create user and log in
       const user = await createTestUser(request);
       expect(user.response.ok()).toBeTruthy();
       await loginViaUI(page, user.email, user.password, browserName);
 
       // Act: navigate to home page
-      await page.goto('/');
+      await page.goto("/");
 
       // Assert: "Submit a Video" shown instead of "Create Free Account"
-      await expect(page.getByRole('link', { name: 'Submit a Video' }).first()).toBeVisible();
-      await expect(page.getByRole('link', { name: 'Create Free Account' })).toHaveCount(0);
+      await expect(
+        page.getByRole("link", { name: "Submit a Video" }).first(),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Create Free Account" }),
+      ).toHaveCount(0);
     });
   });
 
-  test.describe('Stats Strip', () => {
-    test('displays all three stats', async ({ page }) => {
-      await page.goto('/');
+  test.describe("Stats Strip", () => {
+    test("displays all three stats", async ({ page }) => {
+      await page.goto("/");
 
-      await expect(page.getByText('8,000+ Videos Mapped')).toBeVisible();
-      await expect(page.getByText('All 50 States Represented')).toBeVisible();
-      await expect(page.getByText('1st, 2nd, 4th, 5th, and 14th Amendments Indexed')).toBeVisible();
+      await expect(page.getByText("8,000+ Videos Mapped")).toBeVisible();
+      await expect(page.getByText("All 50 States Represented")).toBeVisible();
+      await expect(
+        page.getByText("1st, 2nd, 4th, 5th, and 14th Amendments Indexed"),
+      ).toBeVisible();
     });
   });
 
-  test.describe('How It Works', () => {
-    test('displays heading and three cards', async ({ page }) => {
-      await page.goto('/');
+  test.describe("How It Works", () => {
+    test("displays heading and three cards", async ({ page }) => {
+      await page.goto("/");
 
       await expect(
-        page.getByRole('heading', { name: 'How AccountabilityAtlas Works' })
+        page.getByRole("heading", { name: "How AccountabilityAtlas Works" }),
       ).toBeVisible();
-
-      await expect(page.getByRole('heading', { name: 'Discover' })).toBeVisible();
-      await expect(page.getByText('Browse audit videos geographically')).toBeVisible();
-
-      await expect(page.getByRole('heading', { name: 'Understand' })).toBeVisible();
-      await expect(page.getByText('Filter by constitutional amendment and participant type')).toBeVisible();
-
-      await expect(page.getByRole('heading', { name: 'Contribute' })).toBeVisible();
-      await expect(page.getByText('Submit YouTube videos, tag them')).toBeVisible();
-    });
-  });
-
-  test.describe('Why It Matters', () => {
-    test('displays heading and three cards', async ({ page }) => {
-      await page.goto('/');
 
       await expect(
-        page.getByRole('heading', { name: 'Why Geographic Context Changes Everything' })
+        page.getByRole("heading", { name: "Discover" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Browse audit videos geographically"),
       ).toBeVisible();
 
-      await expect(page.getByRole('heading', { name: 'Pattern Recognition' })).toBeVisible();
-      await expect(page.getByText('trends become visible across jurisdictions')).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Understand" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText(
+          "Filter by constitutional amendment and participant type",
+        ),
+      ).toBeVisible();
 
-      await expect(page.getByRole('heading', { name: 'Public Record' })).toBeVisible();
-      await expect(page.getByText('searchable, geographic archive')).toBeVisible();
-
-      await expect(page.getByRole('heading', { name: 'Civic Transparency' })).toBeVisible();
-      await expect(page.getByText('public accountability and research')).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Contribute" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Submit YouTube videos, tag them"),
+      ).toBeVisible();
     });
   });
 
-  test.describe('Final CTA', () => {
-    test('displays heading and CTA buttons', async ({ page }) => {
-      await page.goto('/');
+  test.describe("Why It Matters", () => {
+    test("displays heading and three cards", async ({ page }) => {
+      await page.goto("/");
 
-      await expect(page.getByRole('heading', { name: 'Start Exploring' })).toBeVisible();
-      await expect(page.getByText('No account required to browse the map.')).toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          name: "Why Geographic Context Changes Everything",
+        }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole("heading", { name: "Pattern Recognition" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("trends become visible across jurisdictions"),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole("heading", { name: "Public Record" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("searchable, geographic archive"),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole("heading", { name: "Civic Transparency" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("public accountability and research"),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("Final CTA", () => {
+    test("displays heading and CTA buttons", async ({ page }) => {
+      await page.goto("/");
+
+      await expect(
+        page.getByRole("heading", { name: "Start Exploring" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("No account required to browse the map."),
+      ).toBeVisible();
 
       // Final CTA section should have Explore the Map and Create Free Account links
-      const exploreLinks = page.getByRole('link', { name: 'Explore the Map' });
+      const exploreLinks = page.getByRole("link", { name: "Explore the Map" });
       await expect(exploreLinks).toHaveCount(2); // Hero + Final CTA
 
-      const createAccountLinks = page.getByRole('link', { name: 'Create Free Account' });
+      const createAccountLinks = page.getByRole("link", {
+        name: "Create Free Account",
+      });
       await expect(createAccountLinks).toHaveCount(2); // Hero + Final CTA
     });
   });
 
-  test.describe('Navigation', () => {
+  test.describe("Navigation", () => {
     test('"Explore the Map" CTA navigates to /map', async ({ page }) => {
-      await page.goto('/');
+      await page.goto("/");
 
       // Click the first "Explore the Map" link (in hero section)
-      await page.getByRole('link', { name: 'Explore the Map' }).first().click();
+      await page.getByRole("link", { name: "Explore the Map" }).first().click();
 
-      await expect(page).toHaveURL('/map', { timeout: PAGE_LOAD_TIMEOUT });
+      await expect(page).toHaveURL("/map", { timeout: PAGE_LOAD_TIMEOUT });
     });
 
-    test('"Create Free Account" CTA navigates to /register', async ({ page }) => {
-      await page.goto('/');
+    test('"Create Free Account" CTA navigates to /register', async ({
+      page,
+    }) => {
+      await page.goto("/");
 
-      await page.getByRole('link', { name: 'Create Free Account' }).first().click();
+      await page
+        .getByRole("link", { name: "Create Free Account" })
+        .first()
+        .click();
 
-      await expect(page).toHaveURL('/register', { timeout: PAGE_LOAD_TIMEOUT });
+      await expect(page).toHaveURL("/register", { timeout: PAGE_LOAD_TIMEOUT });
     });
   });
 
-  test.describe('NavBar', () => {
-    test('NavBar is transparent on home page with z-50 stacking', async ({ page }) => {
-      await page.goto('/');
+  test.describe("NavBar", () => {
+    test("NavBar is transparent on home page with z-50 stacking", async ({
+      page,
+    }) => {
+      await page.goto("/");
 
-      const nav = page.getByRole('navigation');
+      const nav = page.getByRole("navigation");
       await expect(nav).toHaveClass(/bg-transparent/);
       await expect(nav).not.toHaveClass(/border-b/);
       await expect(nav).toHaveClass(/z-50/);
     });
 
-    test('NavBar is opaque on other pages with z-50 stacking', async ({ page }) => {
-      await page.goto('/login');
+    test("NavBar is opaque on other pages with z-50 stacking", async ({
+      page,
+    }) => {
+      await page.goto("/login");
 
-      const nav = page.getByRole('navigation');
+      const nav = page.getByRole("navigation");
       await expect(nav).toHaveClass(/bg-white/);
       await expect(nav).toHaveClass(/border-b/);
       await expect(nav).toHaveClass(/z-50/);

--- a/e2e/tests/map/map-browse.spec.ts
+++ b/e2e/tests/map/map-browse.spec.ts
@@ -1,16 +1,19 @@
 // e2e/tests/map/map-browse.spec.ts
-import { test, expect } from '@playwright/test';
-import { SEED_VIDEOS } from '../../fixtures/seed-data';
-import { PAGE_LOAD_TIMEOUT, UI_INTERACTION_TIMEOUT } from '../../fixtures/test-constants';
-import { mockMapboxSearchAPI } from '../../fixtures/mapbox-search-mock';
+import { test, expect } from "@playwright/test";
+import { SEED_VIDEOS } from "../../fixtures/seed-data";
+import {
+  PAGE_LOAD_TIMEOUT,
+  UI_INTERACTION_TIMEOUT,
+} from "../../fixtures/test-constants";
+import { mockMapboxSearchAPI } from "../../fixtures/mapbox-search-mock";
 
-test.describe('Map Browse', () => {
-  test('map page loads with video markers', async ({ page, browserName }) => {
+test.describe("Map Browse", () => {
+  test("map page loads with video markers", async ({ page, browserName }) => {
     // Act: navigate to map page
-    await page.goto('/map');
+    await page.goto("/map");
 
     // Wait for map to render (WebGL can be slow)
-    if (browserName !== 'chromium') {
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -23,10 +26,13 @@ test.describe('Map Browse', () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  test('clicking marker shows video info popup', async ({ page, browserName }) => {
+  test("clicking marker shows video info popup", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: go to map
-    await page.goto('/map');
-    if (browserName !== 'chromium') {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -38,13 +44,18 @@ test.describe('Map Browse', () => {
     await videoList.first().click();
 
     // Assert: popup appears with View Video link
-    await expect(page.getByRole('link', { name: /View Video/i })).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(page.getByRole("link", { name: /View Video/i })).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
   });
 
-  test('clicking "View Video" navigates to detail page', async ({ page, browserName }) => {
+  test('clicking "View Video" navigates to detail page', async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: go to map and click video in list
-    await page.goto('/map');
-    if (browserName !== 'chromium') {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -54,18 +65,25 @@ test.describe('Map Browse', () => {
     await videoList.first().click();
 
     // Act: click View Video link
-    const viewVideoLink = page.getByRole('link', { name: /View Video/i });
-    await expect(viewVideoLink).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    const viewVideoLink = page.getByRole("link", { name: /View Video/i });
+    await expect(viewVideoLink).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
     await viewVideoLink.click();
 
     // Assert: navigated to video detail page
-    await expect(page).toHaveURL(/\/videos\/[a-f0-9-]+/, { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL(/\/videos\/[a-f0-9-]+/, {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('filter by amendment updates video list', async ({ page, browserName }) => {
+  test("filter by amendment updates video list", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: go to map
-    await page.goto('/map');
-    if (browserName !== 'chromium') {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -77,10 +95,12 @@ test.describe('Map Browse', () => {
     const initialCount = await videoList.count();
 
     // Expand filter bar first
-    await page.getByRole('button', { name: /Filters/i }).click();
+    await page.getByRole("button", { name: /Filters/i }).click();
 
     // Act: click 4th Amendment filter chip (exact: true avoids matching "14th Amendment")
-    await page.getByRole('button', { name: '4th Amendment', exact: true }).click();
+    await page
+      .getByRole("button", { name: "4th Amendment", exact: true })
+      .click();
 
     // Assert: list is filtered (count changes or specific video visible)
     // Note: All seed videos have FIRST, only 3 have FOURTH
@@ -89,10 +109,13 @@ test.describe('Map Browse', () => {
     expect(filteredCount).toBeLessThanOrEqual(initialCount);
   });
 
-  test('filter by participant updates video list', async ({ page, browserName }) => {
+  test("filter by participant updates video list", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: go to map
-    await page.goto('/map');
-    if (browserName !== 'chromium') {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -101,10 +124,10 @@ test.describe('Map Browse', () => {
     await expect(videoList.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // Expand filter bar first
-    await page.getByRole('button', { name: /Filters/i }).click();
+    await page.getByRole("button", { name: /Filters/i }).click();
 
     // Act: click Government filter chip (exact: true ensures only the chip matches, not video list items)
-    await page.getByRole('button', { name: 'Government', exact: true }).click();
+    await page.getByRole("button", { name: "Government", exact: true }).click();
 
     // Assert: Government-tagged videos visible
     await page.waitForTimeout(500);
@@ -112,11 +135,14 @@ test.describe('Map Browse', () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  test('location search flies to location and shows toast', async ({ page, browserName }) => {
+  test("location search flies to location and shows toast", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: mock Mapbox Search API to avoid consuming search sessions
     await mockMapboxSearchAPI(page);
-    await page.goto('/map');
-    if (browserName !== 'chromium') {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -125,23 +151,30 @@ test.describe('Map Browse', () => {
     await expect(videoList.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // Act: type in search box and select result
-    const searchBox = page.getByRole('combobox').or(page.locator('input[placeholder*="Search"]'));
-    await searchBox.fill('Denver');
+    const searchBox = page
+      .getByRole("combobox")
+      .or(page.locator('input[placeholder*="Search"]'));
+    await searchBox.fill("Denver");
 
     // Wait for autocomplete and click first result
-    const suggestion = page.getByRole('option').first();
+    const suggestion = page.getByRole("option").first();
     await expect(suggestion).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
     await suggestion.click();
 
     // Assert: toast appears
-    await expect(page.getByText(/Moved to/i)).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(page.getByText(/Moved to/i)).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
   });
 
-  test('panning map updates video list based on visible area', async ({ page, browserName }) => {
+  test("panning map updates video list based on visible area", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: mock Mapbox Search API to avoid consuming search sessions
     await mockMapboxSearchAPI(page);
-    await page.goto('/map');
-    if (browserName !== 'chromium') {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -152,10 +185,12 @@ test.describe('Map Browse', () => {
     const initialCount = await videoList.count();
 
     // Act: search for "San Antonio" to fly to Texas
-    const searchBox = page.getByRole('combobox').or(page.locator('input[placeholder*="Search"]'));
-    await searchBox.fill('San Antonio');
+    const searchBox = page
+      .getByRole("combobox")
+      .or(page.locator('input[placeholder*="Search"]'));
+    await searchBox.fill("San Antonio");
 
-    const suggestion = page.getByRole('option').first();
+    const suggestion = page.getByRole("option").first();
     await expect(suggestion).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
     await suggestion.click();
 
@@ -167,16 +202,21 @@ test.describe('Map Browse', () => {
     }).toPass({ timeout: PAGE_LOAD_TIMEOUT });
   });
 
-  test('clicking cluster marker zooms to show all member locations', async ({ page, browserName }) => {
+  test("clicking cluster marker zooms to show all member locations", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: go to map at initial zoom (should show clusters at zoom < 8)
-    await page.goto('/map');
-    if (browserName !== 'chromium') {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
     // Wait for cluster markers to load (default zoom shows clusters)
     const clusterMarker = page.locator('[data-testid="cluster-marker"]');
-    await expect(clusterMarker.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(clusterMarker.first()).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // Get initial cluster count before clicking
     const initialClusterCount = await clusterMarker.count();
@@ -186,17 +226,24 @@ test.describe('Map Browse', () => {
 
     // Assert: after fitBounds animation, the view changes (clusters re-render at new zoom)
     await expect(async () => {
-      const videoMarkerCount = await page.locator('[data-testid="video-marker"]').count();
+      const videoMarkerCount = await page
+        .locator('[data-testid="video-marker"]')
+        .count();
       const newClusterCount = await clusterMarker.count();
       // Either individual video markers appear, or cluster count changed (zoomed in)
-      expect(videoMarkerCount > 0 || newClusterCount !== initialClusterCount).toBeTruthy();
+      expect(
+        videoMarkerCount > 0 || newClusterCount !== initialClusterCount,
+      ).toBeTruthy();
     }).toPass({ timeout: PAGE_LOAD_TIMEOUT });
   });
 
-  test('clicking video in list shows marker popup', async ({ page, browserName }) => {
+  test("clicking video in list shows marker popup", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: go to map
-    await page.goto('/map');
-    if (browserName !== 'chromium') {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -208,34 +255,45 @@ test.describe('Map Browse', () => {
     await videoList.first().click();
 
     // Assert: popup appears with View Video link
-    await expect(page.getByRole('link', { name: /View Video/i })).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(page.getByRole("link", { name: /View Video/i })).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
   });
 
-  test('zooming out transitions from individual markers to clusters', async ({ page, browserName }) => {
+  test("zooming out transitions from individual markers to clusters", async ({
+    page,
+    browserName,
+  }) => {
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
 
     // Arrange: navigate to map zoomed in on SF (zoom 14 > cluster threshold 8)
     await page.goto(`/map?lat=${video.lat}&lng=${video.lng}&zoom=14`);
-    if (browserName !== 'chromium') {
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
     // Assert: individual video markers visible at zoom 14
-    await expect(page.locator('[data-testid="video-marker"]').first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(
+      page.locator('[data-testid="video-marker"]').first(),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // Assert: no cluster markers at high zoom
     await expect(page.locator('[data-testid="cluster-marker"]')).toHaveCount(0);
 
     // Act: navigate to same location at zoom 4 (zoomed out — should trigger clustering)
     await page.goto(`/map?lat=${video.lat}&lng=${video.lng}&zoom=4`);
-    if (browserName !== 'chromium') {
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
     // Assert: cluster markers visible at low zoom
-    await expect(page.locator('[data-testid="cluster-marker"]').first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(
+      page.locator('[data-testid="cluster-marker"]').first(),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // Assert: video list is still populated
-    await expect(page.locator('[data-testid="video-list-item"]').first()).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(
+      page.locator('[data-testid="video-list-item"]').first(),
+    ).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
   });
 });

--- a/e2e/tests/profile/my-submissions.spec.ts
+++ b/e2e/tests/profile/my-submissions.spec.ts
@@ -1,32 +1,50 @@
-import { test, expect } from '@playwright/test';
-import { createTestUser, loginViaUI } from '../../fixtures/test-data';
-import { PAGE_LOAD_TIMEOUT } from '../../fixtures/test-constants';
+import { test, expect } from "@playwright/test";
+import { createTestUser, loginViaUI } from "../../fixtures/test-data";
+import { PAGE_LOAD_TIMEOUT } from "../../fixtures/test-constants";
 
-test.describe('My Submissions', () => {
-  test('profile page shows my submissions section', async ({ page, request, browserName }) => {
+test.describe("My Submissions", () => {
+  test("profile page shows my submissions section", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user
-    const user = await createTestUser(request, { displayName: `Submissions ${Date.now()}` });
+    const user = await createTestUser(request, {
+      displayName: `Submissions ${Date.now()}`,
+    });
     expect(user.response.ok()).toBeTruthy();
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile
-    await page.goto('/profile');
+    await page.goto("/profile");
 
     // Assert: submissions section exists (empty for new user)
-    await expect(page.getByText(/my submissions/i)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(/my submissions/i)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('new user sees empty submissions list', async ({ page, request, browserName }) => {
+  test("new user sees empty submissions list", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user
-    const user = await createTestUser(request, { displayName: `Empty Subs ${Date.now()}` });
+    const user = await createTestUser(request, {
+      displayName: `Empty Subs ${Date.now()}`,
+    });
     expect(user.response.ok()).toBeTruthy();
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile
-    await page.goto('/profile');
+    await page.goto("/profile");
 
     // Assert: submissions section exists but is empty for a new user
-    await expect(page.getByText(/my submissions/i)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.locator('[data-testid="submission-item"]')).toHaveCount(0);
+    await expect(page.getByText(/my submissions/i)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.locator('[data-testid="submission-item"]')).toHaveCount(
+      0,
+    );
   });
 });

--- a/e2e/tests/profile/profile-edit.spec.ts
+++ b/e2e/tests/profile/profile-edit.spec.ts
@@ -1,9 +1,16 @@
-import { test, expect } from '@playwright/test';
-import { createTestUser, loginViaUI } from '../../fixtures/test-data';
-import { PAGE_LOAD_TIMEOUT, UI_INTERACTION_TIMEOUT } from '../../fixtures/test-constants';
+import { test, expect } from "@playwright/test";
+import { createTestUser, loginViaUI } from "../../fixtures/test-data";
+import {
+  PAGE_LOAD_TIMEOUT,
+  UI_INTERACTION_TIMEOUT,
+} from "../../fixtures/test-constants";
 
-test.describe('Profile Edit', () => {
-  test('profile page shows current user info', async ({ page, request, browserName }) => {
+test.describe("Profile Edit", () => {
+  test("profile page shows current user info", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user
     const displayName = `Profile View ${Date.now()}`;
     const user = await createTestUser(request, { displayName });
@@ -11,13 +18,19 @@ test.describe('Profile Edit', () => {
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile page
-    await page.goto('/profile');
+    await page.goto("/profile");
 
     // Assert: current user info is displayed
-    await expect(page.getByRole('heading', { name: displayName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByRole("heading", { name: displayName })).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('can edit display name and see update persist', async ({ page, request, browserName }) => {
+  test("can edit display name and see update persist", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user
     const timestamp = Date.now();
     const originalName = `Edit Name ${timestamp}`;
@@ -26,46 +39,64 @@ test.describe('Profile Edit', () => {
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile and edit display name
-    await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: originalName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.goto("/profile");
+    await expect(page.getByRole("heading", { name: originalName })).toBeVisible(
+      { timeout: PAGE_LOAD_TIMEOUT },
+    );
 
     const newName = `Changed Name ${timestamp}`;
     const displayNameInput = page.getByLabel(/display name/i);
     await displayNameInput.clear();
     await displayNameInput.fill(newName);
-    await page.getByRole('button', { name: /save/i }).first().click();
+    await page.getByRole("button", { name: /save/i }).first().click();
 
     // Assert: success feedback shown (avoid matching the new display name)
-    await expect(page.getByText(/saved successfully/i)).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(page.getByText(/saved successfully/i)).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
 
     // Assert: change persists after reload
     await page.reload();
-    await expect(page.getByRole('heading', { name: newName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByRole("heading", { name: newName })).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('can add social links', async ({ page, request, browserName }) => {
+  test("can add social links", async ({ page, request, browserName }) => {
     // Arrange: create and login a user
-    const user = await createTestUser(request, { displayName: `Social Links ${Date.now()}` });
+    const user = await createTestUser(request, {
+      displayName: `Social Links ${Date.now()}`,
+    });
     expect(user.response.ok()).toBeTruthy();
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile and add a YouTube social link
-    await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: user.displayName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.goto("/profile");
+    await expect(
+      page.getByRole("heading", { name: user.displayName }),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     const youtubeInput = page.getByLabel(/youtube/i);
-    await youtubeInput.fill('UCtest123');
-    await page.getByRole('button', { name: /save/i }).last().click();
+    await youtubeInput.fill("UCtest123");
+    await page.getByRole("button", { name: /save/i }).last().click();
 
     // Assert: success feedback shown
-    await expect(page.getByText(/saved|updated/i)).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(page.getByText(/saved|updated/i)).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
 
     // Assert: change persists after reload
     await page.reload();
-    await expect(page.getByLabel(/youtube/i)).toHaveValue('UCtest123', { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByLabel(/youtube/i)).toHaveValue("UCtest123", {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('profile header shows avatar placeholder, trust tier badge, and member since', async ({ page, request, browserName }) => {
+  test("profile header shows avatar placeholder, trust tier badge, and member since", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user
     const displayName = `Header Check ${Date.now()}`;
     const user = await createTestUser(request, { displayName });
@@ -73,76 +104,115 @@ test.describe('Profile Edit', () => {
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile page
-    await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: displayName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.goto("/profile");
+    await expect(page.getByRole("heading", { name: displayName })).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // Assert: avatar placeholder (initials) is visible since no avatar is set
-    await expect(page.locator('[data-testid="profile-avatar-placeholder"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="profile-avatar-placeholder"]'),
+    ).toBeVisible();
 
     // Assert: trust tier badge is visible
-    await expect(page.locator('[data-testid="trust-tier-badge"]')).toBeVisible();
-    await expect(page.locator('[data-testid="trust-tier-badge"]')).toHaveText('NEW');
+    await expect(
+      page.locator('[data-testid="trust-tier-badge"]'),
+    ).toBeVisible();
+    await expect(page.locator('[data-testid="trust-tier-badge"]')).toHaveText(
+      "NEW",
+    );
 
     // Assert: member since is visible
     await expect(page.getByText(/member since/i)).toBeVisible();
 
     // Assert: Change Avatar button is visible
-    await expect(page.locator('[data-testid="change-avatar-button"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="change-avatar-button"]'),
+    ).toBeVisible();
   });
 
-  test('Change Avatar button opens picker with Gravatar source', async ({ page, request, browserName }) => {
+  test("Change Avatar button opens picker with Gravatar source", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user
-    const user = await createTestUser(request, { displayName: `Avatar Pick ${Date.now()}` });
+    const user = await createTestUser(request, {
+      displayName: `Avatar Pick ${Date.now()}`,
+    });
     expect(user.response.ok()).toBeTruthy();
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile and click Change Avatar
-    await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: user.displayName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.goto("/profile");
+    await expect(
+      page.getByRole("heading", { name: user.displayName }),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
     await page.locator('[data-testid="change-avatar-button"]').click();
 
     // Assert: modal opens with Gravatar source
-    await expect(page.locator('[data-testid="avatar-picker-modal"]')).toBeVisible();
-    await expect(page.locator('[data-testid="avatar-source-gravatar"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="avatar-picker-modal"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="avatar-source-gravatar"]'),
+    ).toBeVisible();
   });
 
-  test('selecting Gravatar avatar saves and displays it', async ({ page, request, browserName }) => {
+  test("selecting Gravatar avatar saves and displays it", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user
-    const user = await createTestUser(request, { displayName: `Avatar Save ${Date.now()}` });
+    const user = await createTestUser(request, {
+      displayName: `Avatar Save ${Date.now()}`,
+    });
     expect(user.response.ok()).toBeTruthy();
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile, open picker, select Gravatar
-    await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: user.displayName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.goto("/profile");
+    await expect(
+      page.getByRole("heading", { name: user.displayName }),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
     await page.locator('[data-testid="change-avatar-button"]').click();
-    await expect(page.locator('[data-testid="avatar-picker-modal"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="avatar-picker-modal"]'),
+    ).toBeVisible();
     await page.locator('[data-testid="avatar-source-gravatar"]').click();
 
     // Assert: success toast shown
-    await expect(page.getByText(/saved successfully/i)).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(page.getByText(/saved successfully/i)).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
 
     // Assert: avatar image is now visible (replacing initials placeholder)
     await expect(page.locator('[data-testid="profile-avatar"]')).toBeVisible();
 
     // Assert: avatar persists after reload
     await page.reload();
-    await expect(page.locator('[data-testid="profile-avatar"]')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.locator('[data-testid="profile-avatar"]')).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('selecting Gravatar for a real Gravatar email shows actual avatar image', async ({ page, browserName }) => {
+  test("selecting Gravatar for a real Gravatar email shows actual avatar image", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: register via UI with a known real Gravatar email
-    const email = 'test1@example.com';
-    const password = 'TestPass123!';
-    const displayName = 'Gravatar Test';
+    const email = "test1@example.com";
+    const password = "TestPass123!";
+    const displayName = "Gravatar Test";
 
-    await page.goto('/register');
-    const emailField = page.getByLabel('Email');
-    const nameField = page.getByLabel('Display Name');
-    const passwordField = page.getByLabel('Password', { exact: true });
-    const confirmField = page.getByLabel('Confirm Password');
+    await page.goto("/register");
+    const emailField = page.getByLabel("Email");
+    const nameField = page.getByLabel("Display Name");
+    const passwordField = page.getByLabel("Password", { exact: true });
+    const confirmField = page.getByLabel("Confirm Password");
 
-    if (browserName === 'webkit') {
+    if (browserName === "webkit") {
       await emailField.click();
       await emailField.fill(email);
       await nameField.click();
@@ -158,15 +228,18 @@ test.describe('Profile Edit', () => {
       await confirmField.fill(password);
     }
 
-    await page.getByRole('button', { name: /create account/i }).click();
+    await page.getByRole("button", { name: /create account/i }).click();
 
     // If email is already registered from a previous run, sign in instead
-    const registered = await page.waitForURL('/', { timeout: PAGE_LOAD_TIMEOUT }).then(() => true).catch(() => false);
+    const registered = await page
+      .waitForURL("/", { timeout: PAGE_LOAD_TIMEOUT })
+      .then(() => true)
+      .catch(() => false);
     if (!registered) {
-      await page.goto('/login');
-      const loginEmail = page.getByLabel('Email');
-      const loginPassword = page.getByLabel('Password');
-      if (browserName === 'webkit') {
+      await page.goto("/login");
+      const loginEmail = page.getByLabel("Email");
+      const loginPassword = page.getByLabel("Password");
+      if (browserName === "webkit") {
         await loginEmail.click();
         await loginEmail.fill(email);
         await loginPassword.click();
@@ -175,49 +248,74 @@ test.describe('Profile Edit', () => {
         await loginEmail.fill(email);
         await loginPassword.fill(password);
       }
-      await page.locator('form').getByRole('button', { name: /sign in/i }).click();
-      await expect(page).toHaveURL('/');
+      await page
+        .locator("form")
+        .getByRole("button", { name: /sign in/i })
+        .click();
+      await expect(page).toHaveURL("/");
     }
 
     // Act: navigate to profile, open avatar picker, select Gravatar
-    await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: displayName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.goto("/profile");
+    await expect(page.getByRole("heading", { name: displayName })).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
     await page.locator('[data-testid="change-avatar-button"]').click();
-    await expect(page.locator('[data-testid="avatar-picker-modal"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="avatar-picker-modal"]'),
+    ).toBeVisible();
     await page.locator('[data-testid="avatar-source-gravatar"]').click();
 
     // Assert: success toast
-    await expect(page.getByText(/saved successfully/i)).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(page.getByText(/saved successfully/i)).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
 
     // Assert: real avatar image is displayed (not initials placeholder)
     const avatar = page.locator('[data-testid="profile-avatar"]');
     await expect(avatar).toBeVisible();
-    await expect(avatar).toHaveAttribute('src', /gravatar\.com\/avatar\//);
+    await expect(avatar).toHaveAttribute("src", /gravatar\.com\/avatar\//);
 
     // Assert: initials placeholder is gone
-    await expect(page.locator('[data-testid="profile-avatar-placeholder"]')).not.toBeVisible();
+    await expect(
+      page.locator('[data-testid="profile-avatar-placeholder"]'),
+    ).not.toBeVisible();
 
     // Assert: avatar persists after reload
     await page.reload();
-    await expect(page.locator('[data-testid="profile-avatar"]')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.locator('[data-testid="profile-avatar"]')).toHaveAttribute('src', /gravatar\.com\/avatar\//);
+    await expect(page.locator('[data-testid="profile-avatar"]')).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(
+      page.locator('[data-testid="profile-avatar"]'),
+    ).toHaveAttribute("src", /gravatar\.com\/avatar\//);
   });
 
-  test('can toggle privacy settings', async ({ page, request, browserName }) => {
+  test("can toggle privacy settings", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user
-    const user = await createTestUser(request, { displayName: `Privacy Toggle ${Date.now()}` });
+    const user = await createTestUser(request, {
+      displayName: `Privacy Toggle ${Date.now()}`,
+    });
     expect(user.response.ok()).toBeTruthy();
     await loginViaUI(page, user.email, user.password, browserName);
 
     // Act: navigate to profile and toggle social links visibility
-    await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: user.displayName })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.goto("/profile");
+    await expect(
+      page.getByRole("heading", { name: user.displayName }),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     const socialLinksToggle = page.getByLabel(/social links.*visible/i);
     await socialLinksToggle.click();
 
     // Privacy settings auto-save on toggle — no explicit Save button needed
     // Assert: success feedback shown
-    await expect(page.getByText(/saved|updated/i)).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(page.getByText(/saved|updated/i)).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
   });
 });

--- a/e2e/tests/profile/public-profile.spec.ts
+++ b/e2e/tests/profile/public-profile.spec.ts
@@ -1,30 +1,36 @@
-import { test, expect } from '@playwright/test';
-import { SEED_USERS } from '../../fixtures/seed-data';
-import { PAGE_LOAD_TIMEOUT } from '../../fixtures/test-constants';
-import { createTestUser, loginViaUI } from '../../fixtures/test-data';
+import { test, expect } from "@playwright/test";
+import { SEED_USERS } from "../../fixtures/seed-data";
+import { PAGE_LOAD_TIMEOUT } from "../../fixtures/test-constants";
+import { createTestUser, loginViaUI } from "../../fixtures/test-data";
 
-test.describe('Public Profile', () => {
+test.describe("Public Profile", () => {
   const seedUser = SEED_USERS.TRUSTED_SUBMITTER;
 
-  test('public profile shows display name and avatar', async ({ page }) => {
+  test("public profile shows display name and avatar", async ({ page }) => {
     await page.goto(`/users/${seedUser.id}`);
     // Should show display name (from seed data: "Trusted User")
-    await expect(page.getByRole('heading')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByRole("heading")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
     // Should show member since
     await expect(page.getByText(/member since/i)).toBeVisible();
   });
 
-  test('public profile shows approved video count', async ({ page }) => {
+  test("public profile shows approved video count", async ({ page }) => {
     await page.goto(`/users/${seedUser.id}`);
-    await expect(page.getByText(/\d+ approved video/i)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(/\d+ approved video/i)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('returns 404 for non-existent user', async ({ page }) => {
-    await page.goto('/users/00000000-0000-0000-0000-000000000099');
-    await expect(page.getByText(/not found/i)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  test("returns 404 for non-existent user", async ({ page }) => {
+    await page.goto("/users/00000000-0000-0000-0000-000000000099");
+    await expect(page.getByText(/not found/i)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('public profile shows trust tier badge when authenticated', async ({
+  test("public profile shows trust tier badge when authenticated", async ({
     page,
     request,
     browserName,
@@ -32,17 +38,21 @@ test.describe('Public Profile', () => {
     const user = await createTestUser(request);
     await loginViaUI(page, user.email, user.password, browserName);
     await page.goto(`/users/${seedUser.id}`);
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible({
       timeout: PAGE_LOAD_TIMEOUT,
     });
-    const badge = page.getByTestId('trust-tier-badge');
+    const badge = page.getByTestId("trust-tier-badge");
     await expect(badge).toBeVisible();
-    await expect(badge).toHaveText('TRUSTED');
+    await expect(badge).toHaveText("TRUSTED");
   });
 
-  test('public profile hides trust tier badge when not authenticated', async ({ page }) => {
+  test("public profile hides trust tier badge when not authenticated", async ({
+    page,
+  }) => {
     await page.goto(`/users/${seedUser.id}`);
-    await expect(page.getByRole('heading')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.getByTestId('trust-tier-badge')).not.toBeVisible();
+    await expect(page.getByRole("heading")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.getByTestId("trust-tier-badge")).not.toBeVisible();
   });
 });

--- a/e2e/tests/videos/trusted-auto-approval.spec.ts
+++ b/e2e/tests/videos/trusted-auto-approval.spec.ts
@@ -1,7 +1,10 @@
-import { test, expect } from '@playwright/test';
-import { PAGE_LOAD_TIMEOUT, UI_INTERACTION_TIMEOUT } from '../../fixtures/test-constants';
+import { test, expect } from "@playwright/test";
+import {
+  PAGE_LOAD_TIMEOUT,
+  UI_INTERACTION_TIMEOUT,
+} from "../../fixtures/test-constants";
 
-const API_URL = process.env.API_URL || 'http://localhost:8080/api/v1';
+const API_URL = process.env.API_URL || "http://localhost:8080/api/v1";
 
 /**
  * E2E test verifying that videos submitted by TRUSTED users are auto-approved.
@@ -11,154 +14,174 @@ const API_URL = process.env.API_URL || 'http://localhost:8080/api/v1';
  * video appears on the map — first within a cluster at the initial USA zoom
  * level, then as an individual marker after zooming in.
  */
-test.describe('Trusted User Auto-Approval', () => {
-  test(
-    'video submitted by trusted user is auto-approved and visible on detail page and map',
-    async ({ page, request, browserName }) => {
-      test.setTimeout(120_000);
+test.describe("Trusted User Auto-Approval", () => {
+  test("video submitted by trusted user is auto-approved and visible on detail page and map", async ({
+    page,
+    request,
+    browserName,
+  }) => {
+    test.setTimeout(120_000);
 
-      // 1. Login via browser UI as the trusted user
-      await page.goto('/login');
-      await page.getByLabel('Email').fill('trusted@example.com');
-      await page.getByLabel('Password').fill('password123');
-      await page.locator('form').getByRole('button', { name: /Sign In/i }).click();
-      await expect(page).toHaveURL('/', { timeout: PAGE_LOAD_TIMEOUT });
+    // 1. Login via browser UI as the trusted user
+    await page.goto("/login");
+    await page.getByLabel("Email").fill("trusted@example.com");
+    await page.getByLabel("Password").fill("password123");
+    await page
+      .locator("form")
+      .getByRole("button", { name: /Sign In/i })
+      .click();
+    await expect(page).toHaveURL("/", { timeout: PAGE_LOAD_TIMEOUT });
 
-      // 2. Navigate to the video submission form
-      await page.goto('/videos/new');
-      await expect(page.getByText('Submit a Video')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    // 2. Navigate to the video submission form
+    await page.goto("/videos/new");
+    await expect(page.getByText("Submit a Video")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
-      // 3. Enter YouTube URL and preview
-      await page.getByPlaceholder(/youtube/i).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw');
-      await page.getByRole('button', { name: /Preview/i }).click();
+    // 3. Enter YouTube URL and preview
+    await page
+      .getByPlaceholder(/youtube/i)
+      .fill("https://www.youtube.com/watch?v=jNQXAC9IVRw");
+    await page.getByRole("button", { name: /Preview/i }).click();
 
-      // 4. Wait for preview to load — either the form fields appear (new video)
-      //    or the "View it here" link appears (video already submitted by another browser)
-      const viewItHereLink = page.getByRole('link', { name: /View it here/i });
-      const submitButton = page.locator('form').getByRole('button', { name: /Submit Video/i });
-      await expect(viewItHereLink.or(submitButton)).toBeVisible({
-        timeout: PAGE_LOAD_TIMEOUT,
-      });
+    // 4. Wait for preview to load — either the form fields appear (new video)
+    //    or the "View it here" link appears (video already submitted by another browser)
+    const viewItHereLink = page.getByRole("link", { name: /View it here/i });
+    const submitButton = page
+      .locator("form")
+      .getByRole("button", { name: /Submit Video/i });
+    await expect(viewItHereLink.or(submitButton)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
-      if (await submitButton.isVisible()) {
-        // NEW VIDEO PATH: fill form fields and submit
+    if (await submitButton.isVisible()) {
+      // NEW VIDEO PATH: fill form fields and submit
 
-        // WebGL warmup for the LocationPicker map
-        if (browserName !== 'chromium') {
-          await page.waitForTimeout(1000);
-        }
-
-        // Select amendment (Chip with role="button")
-        await page.getByRole('button', { name: '1st Amendment' }).click();
-
-        // Select participant
-        await page.getByRole('button', { name: 'Police' }).click();
-
-        // Click the LocationPicker map to place a marker
-        const mapCanvas = page.locator('.mapboxgl-canvas');
-        await expect(mapCanvas).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-        await mapCanvas.click({ position: { x: 200, y: 200 } });
-
-        // Wait for reverse geocode to complete
-        await expect(page.getByText('Resolving address...')).toBeHidden({
-          timeout: 10_000,
-        });
-
-        // Submit the form
-        await submitButton.click();
-
-        // Wait for redirect to video detail page (or 409 race condition)
-        let redirected = false;
-        try {
-          await expect(page).toHaveURL(/\/videos\/[a-f0-9-]+/, {
-            timeout: PAGE_LOAD_TIMEOUT,
-          });
-          redirected = true;
-        } catch {
-          // 409 race — another browser submitted first
-        }
-
-        if (!redirected) {
-          // Recover: reload form, preview again (now shows "already exists")
-          await page.goto('/videos/new');
-          await page.getByPlaceholder(/youtube/i).fill(
-            'https://www.youtube.com/watch?v=jNQXAC9IVRw'
-          );
-          await page.getByRole('button', { name: /Preview/i }).click();
-          await expect(viewItHereLink).toBeVisible({
-            timeout: PAGE_LOAD_TIMEOUT,
-          });
-        }
-      }
-
-      // If still on /videos/new (either from initial "already exists" or 409
-      // recovery), click "View it here" to navigate to the existing video
-      if (!/\/videos\/[a-f0-9-]+$/.test(page.url())) {
-        await viewItHereLink.click();
-        await expect(page).toHaveURL(/\/videos\/[a-f0-9-]+/, {
-          timeout: PAGE_LOAD_TIMEOUT,
-        });
-      }
-
-      // 5. On the detail page — wait for APPROVED badge (auto-approval is async)
-      await expect(async () => {
-        await page.reload();
-        await expect(page.getByText('APPROVED')).toBeVisible();
-      }).toPass({ timeout: 30_000, intervals: [2000] });
-
-      // 6. Capture video title and ID from the detail page
-      await expect(page.locator('h1')).toHaveText(/.+/);
-      const videoTitle = await page.locator('h1').textContent();
-      const videoId = page.url().match(/\/videos\/([a-f0-9-]+)/)?.[1];
-      expect(videoId).toBeTruthy();
-
-      // 7. Wait for search service to index the video (async via SQS events).
-      //    This lightweight API poll avoids the WebGL context exhaustion that
-      //    occurs when reloading the map page in a retry loop.
-      await expect(async () => {
-        const searchRes = await request.get(`${API_URL}/search`, {
-          params: { q: videoTitle! },
-        });
-        expect(searchRes.ok()).toBeTruthy();
-        const searchBody = await searchRes.json();
-        const found = searchBody.results.some(
-          (r: { id: string }) => r.id === videoId
-        );
-        expect(found).toBe(true);
-      }).toPass({ timeout: 60_000, intervals: [2000] });
-
-      // 8. Navigate to the map (video is confirmed in search index)
-      await page.goto('/map');
-      if (browserName !== 'chromium') {
+      // WebGL warmup for the LocationPicker map
+      if (browserName !== "chromium") {
         await page.waitForTimeout(1000);
       }
 
-      // 9. Verify cluster markers are visible at initial zoom level
-      const clusterMarkers = page.locator('[data-testid="cluster-marker"]');
-      await expect(clusterMarkers.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+      // Select amendment (Chip with role="button")
+      await page.getByRole("button", { name: "1st Amendment" }).click();
 
-      // 10. Verify our video appears in the side panel video list
-      const videoListItems = page.locator('[data-testid="video-list-item"]');
-      await expect(videoListItems.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-      const ourVideoInList = videoListItems.filter({ hasText: videoTitle! });
-      await expect(ourVideoInList.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+      // Select participant
+      await page.getByRole("button", { name: "Police" }).click();
 
-      // 11. Click the video in the list to zoom into the cluster area
-      //     VideoListItem.onClick calls flyTo(lng, lat, 14) — zoom 14 is past
-      //     the cluster threshold of 8, so individual markers replace clusters.
-      await ourVideoInList.first().click();
+      // Click the LocationPicker map to place a marker
+      const mapCanvas = page.locator(".mapboxgl-canvas");
+      await expect(mapCanvas).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+      await mapCanvas.click({ position: { x: 200, y: 200 } });
 
-      // 12. Wait for zoom animation and individual markers to render
-      const videoMarkers = page.locator('[data-testid="video-marker"]');
-      await expect(videoMarkers.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+      // Wait for reverse geocode to complete
+      await expect(page.getByText("Resolving address...")).toBeHidden({
+        timeout: 10_000,
+      });
 
-      // Clusters should no longer be visible at zoom 14 (>= threshold 8)
-      await expect(clusterMarkers).toHaveCount(0, { timeout: UI_INTERACTION_TIMEOUT });
+      // Submit the form
+      await submitButton.click();
 
-      // 13. Verify the popup/info card appeared with View Video link
-      await expect(
-        page.getByRole('link', { name: /View Video/i })
-      ).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+      // Wait for redirect to video detail page (or 409 race condition)
+      let redirected = false;
+      try {
+        await expect(page).toHaveURL(/\/videos\/[a-f0-9-]+/, {
+          timeout: PAGE_LOAD_TIMEOUT,
+        });
+        redirected = true;
+      } catch {
+        // 409 race — another browser submitted first
+      }
+
+      if (!redirected) {
+        // Recover: reload form, preview again (now shows "already exists")
+        await page.goto("/videos/new");
+        await page
+          .getByPlaceholder(/youtube/i)
+          .fill("https://www.youtube.com/watch?v=jNQXAC9IVRw");
+        await page.getByRole("button", { name: /Preview/i }).click();
+        await expect(viewItHereLink).toBeVisible({
+          timeout: PAGE_LOAD_TIMEOUT,
+        });
+      }
     }
-  );
+
+    // If still on /videos/new (either from initial "already exists" or 409
+    // recovery), click "View it here" to navigate to the existing video
+    if (!/\/videos\/[a-f0-9-]+$/.test(page.url())) {
+      await viewItHereLink.click();
+      await expect(page).toHaveURL(/\/videos\/[a-f0-9-]+/, {
+        timeout: PAGE_LOAD_TIMEOUT,
+      });
+    }
+
+    // 5. On the detail page — wait for APPROVED badge (auto-approval is async)
+    await expect(async () => {
+      await page.reload();
+      await expect(page.getByText("APPROVED")).toBeVisible();
+    }).toPass({ timeout: 30_000, intervals: [2000] });
+
+    // 6. Capture video title and ID from the detail page
+    await expect(page.locator("h1")).toHaveText(/.+/);
+    const videoTitle = await page.locator("h1").textContent();
+    const videoId = page.url().match(/\/videos\/([a-f0-9-]+)/)?.[1];
+    expect(videoId).toBeTruthy();
+
+    // 7. Wait for search service to index the video (async via SQS events).
+    //    This lightweight API poll avoids the WebGL context exhaustion that
+    //    occurs when reloading the map page in a retry loop.
+    await expect(async () => {
+      const searchRes = await request.get(`${API_URL}/search`, {
+        params: { q: videoTitle! },
+      });
+      expect(searchRes.ok()).toBeTruthy();
+      const searchBody = await searchRes.json();
+      const found = searchBody.results.some(
+        (r: { id: string }) => r.id === videoId,
+      );
+      expect(found).toBe(true);
+    }).toPass({ timeout: 60_000, intervals: [2000] });
+
+    // 8. Navigate to the map (video is confirmed in search index)
+    await page.goto("/map");
+    if (browserName !== "chromium") {
+      await page.waitForTimeout(1000);
+    }
+
+    // 9. Verify cluster markers are visible at initial zoom level
+    const clusterMarkers = page.locator('[data-testid="cluster-marker"]');
+    await expect(clusterMarkers.first()).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+
+    // 10. Verify our video appears in the side panel video list
+    const videoListItems = page.locator('[data-testid="video-list-item"]');
+    await expect(videoListItems.first()).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    const ourVideoInList = videoListItems.filter({ hasText: videoTitle! });
+    await expect(ourVideoInList.first()).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+
+    // 11. Click the video in the list to zoom into the cluster area
+    //     VideoListItem.onClick calls flyTo(lng, lat, 14) — zoom 14 is past
+    //     the cluster threshold of 8, so individual markers replace clusters.
+    await ourVideoInList.first().click();
+
+    // 12. Wait for zoom animation and individual markers to render
+    const videoMarkers = page.locator('[data-testid="video-marker"]');
+    await expect(videoMarkers.first()).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+
+    // Clusters should no longer be visible at zoom 14 (>= threshold 8)
+    await expect(clusterMarkers).toHaveCount(0, {
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
+
+    // 13. Verify the popup/info card appeared with View Video link
+    await expect(page.getByRole("link", { name: /View Video/i })).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
+  });
 });

--- a/e2e/tests/videos/video-detail.spec.ts
+++ b/e2e/tests/videos/video-detail.spec.ts
@@ -1,57 +1,78 @@
 // e2e/tests/videos/video-detail.spec.ts
-import { test, expect } from '@playwright/test';
-import { SEED_VIDEOS, NON_EXISTENT_VIDEO_ID } from '../../fixtures/seed-data';
-import { createTestUser, loginViaUI } from '../../fixtures/test-data';
-import { PAGE_LOAD_TIMEOUT, UI_INTERACTION_TIMEOUT } from '../../fixtures/test-constants';
+import { test, expect } from "@playwright/test";
+import { SEED_VIDEOS, NON_EXISTENT_VIDEO_ID } from "../../fixtures/seed-data";
+import { createTestUser, loginViaUI } from "../../fixtures/test-data";
+import {
+  PAGE_LOAD_TIMEOUT,
+  UI_INTERACTION_TIMEOUT,
+} from "../../fixtures/test-constants";
 
-test.describe('Video Detail', () => {
-  test('video detail page shows video information', async ({ page }) => {
+test.describe("Video Detail", () => {
+  test("video detail page shows video information", async ({ page }) => {
     // Arrange: navigate directly to a known video
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
 
     // Assert: title is visible
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(video.title)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // Assert: YouTube embed is present
-    const iframe = page.locator(`iframe[src*="youtube.com/embed/${video.youtubeId}"]`);
+    const iframe = page.locator(
+      `iframe[src*="youtube.com/embed/${video.youtubeId}"]`,
+    );
     await expect(iframe).toBeVisible();
 
     // Assert: amendment chip is visible (rewritten page shows formatted labels like "1st Amendment")
-    await expect(page.getByText('1st Amendment')).toBeVisible();
+    await expect(page.getByText("1st Amendment")).toBeVisible();
   });
 
-  test('video detail page shows location information', async ({ page }) => {
+  test("video detail page shows location information", async ({ page }) => {
     // Arrange: navigate to known video
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
 
     // Assert: location info visible - verify city appears in the location section
-    await expect(page.getByText(video.city)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(video.city)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
     // Verify state appears alongside city (the format is "displayName, city, state")
-    await expect(page.getByText(new RegExp(`${video.city},\\s*${video.state}`))).toBeVisible();
+    await expect(
+      page.getByText(new RegExp(`${video.city},\\s*${video.state}`)),
+    ).toBeVisible();
   });
 
-  test('location link navigates to map with coordinates', async ({ page }) => {
+  test("location link navigates to map with coordinates", async ({ page }) => {
     // Arrange: navigate to known video
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(video.title)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // Assert: location link includes lat/lng/zoom query params ("View on Map" style link)
     const locationLink = page.locator(`a[href*="/map?lat="]`);
     await expect(locationLink).toBeVisible();
-    await expect(locationLink).toHaveAttribute('href', /\/map\?lat=[\d.-]+&lng=[\d.-]+&zoom=14/);
+    await expect(locationLink).toHaveAttribute(
+      "href",
+      /\/map\?lat=[\d.-]+&lng=[\d.-]+&zoom=14/,
+    );
   });
 
-  test('video detail page renders mini-map with location', async ({ page, browserName }) => {
+  test("video detail page renders mini-map with location", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: navigate to known video
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(video.title)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // WebGL warmup for non-Chromium browsers
-    if (browserName !== 'chromium') {
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
@@ -60,14 +81,21 @@ test.describe('Video Detail', () => {
     await expect(miniMap).toBeVisible();
 
     // Assert: Mapbox canvas initialized inside mini-map (confirms WebGL rendered)
-    await expect(miniMap.locator('.mapboxgl-canvas')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(miniMap.locator(".mapboxgl-canvas")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
   });
 
-  test('clicking location link navigates to map and shows video marker', async ({ page, browserName }) => {
+  test("clicking location link navigates to map and shows video marker", async ({
+    page,
+    browserName,
+  }) => {
     // Arrange: navigate to known video
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(video.title)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // Act: click the location link (same selector as existing href-only test)
     const locationLink = page.locator('a[href*="/map?lat="]');
@@ -75,21 +103,27 @@ test.describe('Video Detail', () => {
     await locationLink.click();
 
     // Assert: URL matches /map?lat=...&lng=...&zoom=14
-    await expect(page).toHaveURL(/\/map\?lat=[\d.-]+&lng=[\d.-]+&zoom=14/, { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL(/\/map\?lat=[\d.-]+&lng=[\d.-]+&zoom=14/, {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // WebGL warmup for non-Chromium browsers
-    if (browserName !== 'chromium') {
+    if (browserName !== "chromium") {
       await page.waitForTimeout(1000);
     }
 
     // Assert: individual video marker visible (zoom 14 is above cluster threshold of 8)
-    await expect(page.locator('[data-testid="video-marker"]').first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(
+      page.locator('[data-testid="video-marker"]').first(),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // Assert: no cluster markers at this zoom level
     await expect(page.locator('[data-testid="cluster-marker"]')).toHaveCount(0);
 
     // Assert: video list is populated
-    await expect(page.locator('[data-testid="video-list-item"]').first()).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+    await expect(
+      page.locator('[data-testid="video-list-item"]').first(),
+    ).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
   });
 
   test('"Watch on YouTube" link has correct URL', async ({ page }) => {
@@ -99,7 +133,9 @@ test.describe('Video Detail', () => {
 
     // Assert: YouTube link has correct href (embedded in the iframe, not a standalone link)
     // The rewritten page has an iframe embed; verify it points to the correct YouTube video
-    const iframe = page.locator(`iframe[src*="youtube.com/embed/${video.youtubeId}"]`);
+    const iframe = page.locator(
+      `iframe[src*="youtube.com/embed/${video.youtubeId}"]`,
+    );
     await expect(iframe).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
   });
 
@@ -107,49 +143,63 @@ test.describe('Video Detail', () => {
     // Arrange: navigate to known video
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(video.title)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // Act: click Back to Map link in sidebar
-    await page.getByRole('link', { name: /Back to Map/i }).click();
+    await page.getByRole("link", { name: /Back to Map/i }).click();
 
     // Assert: at map page
-    await expect(page).toHaveURL('/map');
+    await expect(page).toHaveURL("/map");
   });
 
-  test('shows error for non-existent video', async ({ page }) => {
+  test("shows error for non-existent video", async ({ page }) => {
     // Act: navigate to non-existent video
     await page.goto(`/videos/${NON_EXISTENT_VIDEO_ID}`);
 
     // Assert: error message shown
-    await expect(page.getByText(/not found/i)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(/not found/i)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // Assert: link back to map exists
-    await expect(page.getByRole('link', { name: 'Back to Map' })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Back to Map" })).toBeVisible();
   });
 
-  test('video detail page shows participant chips', async ({ page }) => {
+  test("video detail page shows participant chips", async ({ page }) => {
     // Arrange: navigate to a video with known participants
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
 
     // Assert: participant chips display formatted labels (e.g., "Police" instead of "POLICE")
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.getByText('Police')).toBeVisible();
-    await expect(page.getByText('Government', { exact: true })).toBeVisible();
+    await expect(page.getByText(video.title)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.getByText("Police")).toBeVisible();
+    await expect(page.getByText("Government", { exact: true })).toBeVisible();
   });
 
-  test('video detail page shows multi-amendment video correctly', async ({ page }) => {
+  test("video detail page shows multi-amendment video correctly", async ({
+    page,
+  }) => {
     // Arrange: navigate to a video with multiple amendments
     const video = SEED_VIDEOS.OAKLAND_MULTI_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
 
     // Assert: both amendment chips are visible
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.getByText('1st Amendment')).toBeVisible();
-    await expect(page.getByText('4th Amendment')).toBeVisible();
+    await expect(page.getByText(video.title)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.getByText("1st Amendment")).toBeVisible();
+    await expect(page.getByText("4th Amendment")).toBeVisible();
   });
 
-  test('submitter link navigates to public profile', async ({ page, request, browserName }) => {
+  test("submitter link navigates to public profile", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create and login a user (submitter link only visible when authenticated)
     const user = await createTestUser(request);
     expect(user.response.ok()).toBeTruthy();
@@ -158,18 +208,22 @@ test.describe('Video Detail', () => {
     // Act: navigate to a seed video detail page
     const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
     await page.goto(`/videos/${video.id}`);
-    await expect(page.getByText(video.title)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText(video.title)).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
 
     // Assert: submitter link is visible and points to /users/{id}
-    const submitterLink = page.getByRole('link', { name: /Trusted User/i });
+    const submitterLink = page.getByRole("link", { name: /Trusted User/i });
     await expect(submitterLink).toBeVisible();
-    await expect(submitterLink).toHaveAttribute('href', /\/users\/.+/);
+    await expect(submitterLink).toHaveAttribute("href", /\/users\/.+/);
 
     // Act: click the submitter link
     await submitterLink.click();
 
     // Assert: navigated to the public profile page
     await expect(page).toHaveURL(/\/users\//);
-    await expect(page.getByRole('heading', { name: /Trusted User/i })).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(
+      page.getByRole("heading", { name: /Trusted User/i }),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
   });
 });

--- a/e2e/tests/videos/video-submission.spec.ts
+++ b/e2e/tests/videos/video-submission.spec.ts
@@ -1,26 +1,30 @@
-import { test, expect } from '@playwright/test';
-import { createTestUser } from '../../fixtures/test-data';
-import { PAGE_LOAD_TIMEOUT } from '../../fixtures/test-constants';
+import { test, expect } from "@playwright/test";
+import { createTestUser } from "../../fixtures/test-data";
+import { PAGE_LOAD_TIMEOUT } from "../../fixtures/test-constants";
 
-test.describe('Video Submission', () => {
-  test('unauthenticated user is redirected to login', async ({ page }) => {
-    await page.goto('/videos/new');
+test.describe("Video Submission", () => {
+  test("unauthenticated user is redirected to login", async ({ page }) => {
+    await page.goto("/videos/new");
 
     // Should redirect to /login with redirect param
     await expect(page).toHaveURL(/\/login/, { timeout: PAGE_LOAD_TIMEOUT });
   });
 
-  test('submit video page is accessible after login', async ({ page, request, browserName }) => {
+  test("submit video page is accessible after login", async ({
+    page,
+    request,
+    browserName,
+  }) => {
     // Arrange: create a user via API
     const user = await createTestUser(request);
     expect(user.response.ok()).toBeTruthy();
 
     // Act: login with redirect to submission page
-    await page.goto('/login?redirect=/videos/new');
-    const emailField = page.getByLabel('Email');
-    const passwordField = page.getByLabel('Password');
+    await page.goto("/login?redirect=/videos/new");
+    const emailField = page.getByLabel("Email");
+    const passwordField = page.getByLabel("Password");
 
-    if (browserName === 'webkit') {
+    if (browserName === "webkit") {
       await emailField.click();
       await emailField.fill(user.email);
       await passwordField.click();
@@ -29,17 +33,20 @@ test.describe('Video Submission', () => {
       await emailField.fill(user.email);
       await passwordField.fill(user.password);
     }
-    await page.locator('form').getByRole('button', { name: /Sign In/i }).click();
+    await page
+      .locator("form")
+      .getByRole("button", { name: /Sign In/i })
+      .click();
 
     // Assert: redirected to video submission page
-    await expect(page).toHaveURL('/videos/new', { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL("/videos/new", { timeout: PAGE_LOAD_TIMEOUT });
 
     // Verify key form elements are present
-    await expect(page.getByText('Submit a Video')).toBeVisible();
+    await expect(page.getByText("Submit a Video")).toBeVisible();
     await expect(page.getByPlaceholder(/youtube/i)).toBeVisible();
   });
 
-  test('nav bar shows Submit Video button when authenticated', async ({
+  test("nav bar shows Submit Video button when authenticated", async ({
     page,
     request,
     browserName,
@@ -49,11 +56,11 @@ test.describe('Video Submission', () => {
     expect(user.response.ok()).toBeTruthy();
 
     // Act: login through UI
-    await page.goto('/login');
-    const emailField = page.getByLabel('Email');
-    const passwordField = page.getByLabel('Password');
+    await page.goto("/login");
+    const emailField = page.getByLabel("Email");
+    const passwordField = page.getByLabel("Password");
 
-    if (browserName === 'webkit') {
+    if (browserName === "webkit") {
       await emailField.click();
       await emailField.fill(user.email);
       await passwordField.click();
@@ -62,21 +69,30 @@ test.describe('Video Submission', () => {
       await emailField.fill(user.email);
       await passwordField.fill(user.password);
     }
-    await page.locator('form').getByRole('button', { name: /Sign In/i }).click();
-    await expect(page).toHaveURL('/');
+    await page
+      .locator("form")
+      .getByRole("button", { name: /Sign In/i })
+      .click();
+    await expect(page).toHaveURL("/");
 
     // Assert: Submit Video button is visible in nav
-    await expect(page.getByRole('link', { name: /Submit Video/i })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Submit Video/i }),
+    ).toBeVisible();
   });
 
-  test('nav bar does not show Submit Video button when unauthenticated', async ({ page }) => {
-    await page.goto('/');
+  test("nav bar does not show Submit Video button when unauthenticated", async ({
+    page,
+  }) => {
+    await page.goto("/");
 
     // Assert: Submit Video button is NOT visible
-    await expect(page.getByRole('link', { name: /Submit Video/i })).toBeHidden();
+    await expect(
+      page.getByRole("link", { name: /Submit Video/i }),
+    ).toBeHidden();
   });
 
-  test('Submit Video nav link navigates to submission page', async ({
+  test("Submit Video nav link navigates to submission page", async ({
     page,
     request,
     browserName,
@@ -85,11 +101,11 @@ test.describe('Video Submission', () => {
     const user = await createTestUser(request);
     expect(user.response.ok()).toBeTruthy();
 
-    await page.goto('/login');
-    const emailField = page.getByLabel('Email');
-    const passwordField = page.getByLabel('Password');
+    await page.goto("/login");
+    const emailField = page.getByLabel("Email");
+    const passwordField = page.getByLabel("Password");
 
-    if (browserName === 'webkit') {
+    if (browserName === "webkit") {
       await emailField.click();
       await emailField.fill(user.email);
       await passwordField.click();
@@ -98,14 +114,17 @@ test.describe('Video Submission', () => {
       await emailField.fill(user.email);
       await passwordField.fill(user.password);
     }
-    await page.locator('form').getByRole('button', { name: /Sign In/i }).click();
-    await expect(page).toHaveURL('/');
+    await page
+      .locator("form")
+      .getByRole("button", { name: /Sign In/i })
+      .click();
+    await expect(page).toHaveURL("/");
 
     // Act: click Submit Video link in nav
-    await page.getByRole('link', { name: /Submit Video/i }).click();
+    await page.getByRole("link", { name: /Submit Video/i }).click();
 
     // Assert: navigated to submission page
-    await expect(page).toHaveURL('/videos/new', { timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.getByText('Submit a Video')).toBeVisible();
+    await expect(page).toHaveURL("/videos/new", { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByText("Submit a Video")).toBeVisible();
   });
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,31 +1,37 @@
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
-import playwright from 'eslint-plugin-playwright';
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import playwright from "eslint-plugin-playwright";
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    files: ['e2e/**/*.ts', 'api/**/*.ts'],
-    ...playwright.configs['flat/recommended'],
+    files: ["e2e/**/*.ts", "api/**/*.ts"],
+    ...playwright.configs["flat/recommended"],
     rules: {
-      ...playwright.configs['flat/recommended'].rules,
-      'playwright/expect-expect': 'error',
-      'playwright/no-focused-test': 'error',
-      'playwright/valid-expect': 'error',
+      ...playwright.configs["flat/recommended"].rules,
+      "playwright/expect-expect": "error",
+      "playwright/no-focused-test": "error",
+      "playwright/valid-expect": "error",
       // Integration tests legitimately use conditionals for browser-specific
       // WebGL warmup and parallel-browser race condition handling
-      'playwright/no-conditional-in-test': 'off',
-      'playwright/no-conditional-expect': 'off',
+      "playwright/no-conditional-in-test": "off",
+      "playwright/no-conditional-expect": "off",
       // WebGL warmup delays are necessary for Firefox/WebKit (see MEMORY.md)
-      'playwright/no-wait-for-timeout': 'off',
+      "playwright/no-wait-for-timeout": "off",
       // Skipped tests should be tracked and resolved
-      'playwright/no-skipped-test': 'warn',
+      "playwright/no-skipped-test": "warn",
       // Force option needed for Mapbox canvas interactions
-      'playwright/no-force-option': 'off',
+      "playwright/no-force-option": "off",
     },
   },
   {
-    ignores: ['node_modules/', 'dist/', 'infra/', '**/playwright-report/', '**/test-results/'],
-  }
+    ignores: [
+      "node_modules/",
+      "dist/",
+      "infra/",
+      "**/playwright-report/",
+      "**/test-results/",
+    ],
+  },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@typescript-eslint/parser": "^8.54.0",
         "eslint": "^9.39.2",
         "eslint-plugin-playwright": "^2.5.1",
+        "prettier": "^3.8.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.54.0"
       }
@@ -1411,6 +1412,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "report": "playwright show-report e2e/playwright-report",
     "report:api": "playwright show-report api/playwright-report",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "check": "npm run format:check && npm run lint"
   },
   "keywords": [
     "e2e",
@@ -29,6 +32,7 @@
     "@typescript-eslint/parser": "^8.54.0",
     "eslint": "^9.39.2",
     "eslint-plugin-playwright": "^2.5.1",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0"
   }


### PR DESCRIPTION
## Summary

- Add comprehensive E2E tests for the new hero landing page (AcctAtlas-web-app#53, merged)
- 11 tests across Chromium, Firefox, and WebKit covering all 5 page sections, auth-aware CTAs, navigation, and NavBar transparency/z-50 stacking

Closes #36

## Test plan

- [x] All 33 E2E tests pass across 3 browsers
- [x] No regressions in existing tests (171 total E2E pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)