### PR TITLE
fix(api): expect absent rejectionReason instead of null

### DIFF
--- a/api/tests/video-service.spec.ts
+++ b/api/tests/video-service.spec.ts
@@ -360,14 +360,16 @@ test.describe("Video Service API", () => {
 
           expect(listResponse.ok()).toBeTruthy();
           const listBody = await listResponse.json();
-          // Video should be PENDING (no rejection reason yet)
+          // Video should be PENDING with no rejection reason.
+          // Jackson non_null config omits null fields, so rejectionReason
+          // is absent rather than explicitly null.
           const found = listBody.content.find(
             (v: { id: string }) => v.id === video.id,
           );
           expect(found).toMatchObject({
             status: "PENDING",
-            rejectionReason: null,
           });
+          expect(found.rejectionReason).toBeUndefined();
         }
         // If 409, video already exists from a prior run — test is still valid:
         // the schema test (rejectionReason field) was verified in a previous run


### PR DESCRIPTION
## Summary
- Fix video-service rejection reason test to match Jackson `non_null` serialization behavior
- Video-service uses `default-property-inclusion: non_null`, so null fields are omitted from JSON responses rather than serialized as `null`
- Changed assertion from `toMatchObject({ rejectionReason: null })` to `toBeUndefined()`

## Test plan
- [x] All 104 API integration tests pass locally
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)