### PR TITLE
test: add E2E tests for UI polish features (#46)

### DIFF
--- a/e2e/tests/auth/login-redirect.spec.ts
+++ b/e2e/tests/auth/login-redirect.spec.ts
@@ -1,0 +1,86 @@
+// e2e/tests/auth/login-redirect.spec.ts
+import { test, expect } from "@playwright/test";
+import { createTestUser } from "../../fixtures/test-data";
+import {
+  PAGE_LOAD_TIMEOUT,
+  UI_INTERACTION_TIMEOUT,
+} from "../../fixtures/test-constants";
+
+test.describe("Login Redirect", () => {
+  test("Sign In link from map passes redirect param", async ({
+    page,
+    browserName,
+  }) => {
+    // Arrange: go to map page (not logged in)
+    await page.goto("/map");
+    if (browserName !== "chromium") {
+      await page.waitForTimeout(1000);
+    }
+
+    // Act: click Sign In in the nav bar
+    await page.getByRole("link", { name: /Sign In/i }).click();
+
+    // Assert: redirected to login with redirect param
+    await expect(page).toHaveURL(/\/login\?redirect=%2Fmap/, {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+  });
+
+  test("Sign In link from home page has no redirect param", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Act: click Sign In
+    await page.getByRole("link", { name: /Sign In/i }).click();
+
+    // Assert: plain /login with no redirect param
+    await expect(page).toHaveURL("/login", { timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  test("after login, redirects back to original page", async ({
+    page,
+    request,
+    browserName,
+  }) => {
+    // Arrange: create a test user
+    const user = await createTestUser(request);
+    expect(user.response.ok()).toBeTruthy();
+
+    // Navigate to map, then click Sign In
+    await page.goto("/map");
+    if (browserName !== "chromium") {
+      await page.waitForTimeout(1000);
+    }
+    await page.getByRole("link", { name: /Sign In/i }).click();
+    await expect(page).toHaveURL(/\/login\?redirect=%2Fmap/, {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+
+    // Act: fill in credentials and submit
+    const emailField = page.getByLabel("Email");
+    const passwordField = page.getByLabel("Password");
+
+    if (browserName === "webkit") {
+      await emailField.click();
+      await emailField.fill(user.email);
+      await passwordField.click();
+      await passwordField.fill(user.password);
+    } else {
+      await emailField.fill(user.email);
+      await passwordField.fill(user.password);
+    }
+    await page
+      .locator("form")
+      .getByRole("button", { name: /Sign In/i })
+      .click();
+
+    // Assert: redirected back to /map (not /)
+    await expect(page).toHaveURL("/map", { timeout: PAGE_LOAD_TIMEOUT });
+
+    // Assert: user is logged in (nav shows display name or avatar)
+    await expect(
+      page.getByRole("navigation").getByText(user.displayName),
+    ).toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+  });
+});

--- a/e2e/tests/home/page-titles.spec.ts
+++ b/e2e/tests/home/page-titles.spec.ts
@@ -1,0 +1,106 @@
+// e2e/tests/home/page-titles.spec.ts
+import { test, expect } from "@playwright/test";
+import { SEED_VIDEOS, SEED_USERS } from "../../fixtures/seed-data";
+import { PAGE_LOAD_TIMEOUT } from "../../fixtures/test-constants";
+import { createTestUser, loginViaUI } from "../../fixtures/test-data";
+
+test.describe("Page Titles", () => {
+  test.describe("static pages", () => {
+    test("home page has default title", async ({ page }) => {
+      await page.goto("/");
+      await expect(page).toHaveTitle("AccountabilityAtlas");
+    });
+
+    test("login page has correct title", async ({ page }) => {
+      await page.goto("/login");
+      await expect(page).toHaveTitle("Sign In | AccountabilityAtlas");
+    });
+
+    test("register page has correct title", async ({ page }) => {
+      await page.goto("/register");
+      await expect(page).toHaveTitle("Register | AccountabilityAtlas");
+    });
+
+    test("map page has correct title", async ({ page, browserName }) => {
+      await page.goto("/map");
+      if (browserName !== "chromium") {
+        await page.waitForTimeout(1000);
+      }
+      await expect(page).toHaveTitle("Map | AccountabilityAtlas");
+    });
+
+    test("submit video page has correct title", async ({
+      page,
+      request,
+      browserName,
+    }) => {
+      // Must be logged in to access submit page
+      const user = await createTestUser(request);
+      expect(user.response.ok()).toBeTruthy();
+      await loginViaUI(page, user.email, user.password, browserName);
+
+      await page.goto("/videos/new");
+      await expect(page).toHaveTitle("Submit Video | AccountabilityAtlas");
+    });
+
+    test("profile page has correct title", async ({
+      page,
+      request,
+      browserName,
+    }) => {
+      const user = await createTestUser(request);
+      expect(user.response.ok()).toBeTruthy();
+      await loginViaUI(page, user.email, user.password, browserName);
+
+      await page.goto("/profile");
+      await expect(page).toHaveTitle("My Profile | AccountabilityAtlas");
+    });
+  });
+
+  test.describe("dynamic pages", () => {
+    test("video detail page shows video title", async ({ page }) => {
+      const video = SEED_VIDEOS.SILVERTHORNE_GOVERNMENT;
+      await page.goto(`/videos/${video.id}`);
+
+      // Wait for page to load video data
+      await expect(page.getByText(video.title)).toBeVisible({
+        timeout: PAGE_LOAD_TIMEOUT,
+      });
+
+      await expect(page).toHaveTitle(`${video.title} | AccountabilityAtlas`);
+    });
+
+    test("video detail page falls back for non-existent video", async ({
+      page,
+    }) => {
+      await page.goto("/videos/00000000-0000-0000-0000-000000000000");
+
+      await expect(page).toHaveTitle("Video | AccountabilityAtlas", {
+        timeout: PAGE_LOAD_TIMEOUT,
+      });
+    });
+
+    test("public profile page shows user display name", async ({ page }) => {
+      const user = SEED_USERS.TRUSTED_SUBMITTER;
+      await page.goto(`/users/${user.id}`);
+
+      await expect(page.getByRole("heading")).toBeVisible({
+        timeout: PAGE_LOAD_TIMEOUT,
+      });
+
+      await expect(page).toHaveTitle(
+        `${user.displayName} | AccountabilityAtlas`,
+      );
+    });
+
+    test("public profile page falls back for non-existent user", async ({
+      page,
+    }) => {
+      await page.goto("/users/00000000-0000-0000-0000-000000000099");
+
+      await expect(page).toHaveTitle("User Profile | AccountabilityAtlas", {
+        timeout: PAGE_LOAD_TIMEOUT,
+      });
+    });
+  });
+});

--- a/e2e/tests/map/map-home-button.spec.ts
+++ b/e2e/tests/map/map-home-button.spec.ts
@@ -1,0 +1,87 @@
+// e2e/tests/map/map-home-button.spec.ts
+import { test, expect } from "@playwright/test";
+import { SEED_VIDEOS } from "../../fixtures/seed-data";
+import {
+  PAGE_LOAD_TIMEOUT,
+  UI_INTERACTION_TIMEOUT,
+} from "../../fixtures/test-constants";
+
+test.describe("Map Home Button", () => {
+  test("home button is visible on map page", async ({ page, browserName }) => {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
+      await page.waitForTimeout(1000);
+    }
+
+    // Wait for map to be ready
+    const videoList = page.locator('[data-testid="video-list-item"]');
+    await expect(videoList.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await expect(page.getByLabel("Reset map view")).toBeVisible();
+  });
+
+  test("home button resets map and refreshes video list after zooming in", async ({
+    page,
+    browserName,
+  }) => {
+    const video = SEED_VIDEOS.SF_FIRST_AMENDMENT;
+
+    // Arrange: navigate to map zoomed in on SF (zoom 14)
+    await page.goto(`/map?lat=${video.lat}&lng=${video.lng}&zoom=14`);
+    if (browserName !== "chromium") {
+      await page.waitForTimeout(1000);
+    }
+
+    // Wait for zoomed-in view to load (individual markers, not clusters)
+    await expect(
+      page.locator('[data-testid="video-marker"]').first(),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Record zoomed-in video count (should be fewer than all seed videos)
+    const videoList = page.locator('[data-testid="video-list-item"]');
+    await expect(videoList.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    const zoomedInCount = await videoList.count();
+
+    // Act: click home button to reset map view
+    await page.getByLabel("Reset map view").click();
+
+    // Assert: map resets to default zoom (4) which shows clusters
+    // Wait for cluster markers to appear (default zoom < cluster threshold)
+    await expect(
+      page.locator('[data-testid="cluster-marker"]').first(),
+    ).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Assert: video list refreshes with more videos (full US view)
+    await expect(async () => {
+      const resetCount = await videoList.count();
+      expect(resetCount).toBeGreaterThan(zoomedInCount);
+    }).toPass({ timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  test("home button clears selected video", async ({ page, browserName }) => {
+    await page.goto("/map");
+    if (browserName !== "chromium") {
+      await page.waitForTimeout(1000);
+    }
+
+    // Wait for video list to load
+    const videoList = page.locator('[data-testid="video-list-item"]');
+    await expect(videoList.first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Select a video by clicking it in the list
+    await videoList.first().click();
+
+    // Verify popup appeared
+    await expect(page.getByRole("link", { name: /View Video/i })).toBeVisible({
+      timeout: UI_INTERACTION_TIMEOUT,
+    });
+
+    // Act: click home button
+    await page.getByLabel("Reset map view").click();
+
+    // Assert: popup is dismissed
+    await expect(
+      page.getByRole("link", { name: /View Video/i }),
+    ).not.toBeVisible({ timeout: UI_INTERACTION_TIMEOUT });
+  });
+});


### PR DESCRIPTION
## Summary

- **`page-titles.spec.ts`**: 10 tests verifying browser tab titles for static routes (home, map, login, register, submit video, profile) and dynamic routes (video detail, public profile) across Chromium, Firefox, and WebKit
- **`map-home-button.spec.ts`**: 3 tests for the home button — visibility, map reset behavior, and clearing video selection
- **`login-redirect.spec.ts`**: 3 tests for login redirect — `?redirect=` param on Sign In link, round-trip login→redirect back to original page

## Test plan

- [x] All 252 tests pass locally (119 API + 133 E2E)
- [x] CI passes

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)